### PR TITLE
Fix setup.py build failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DESCRIPTION = 'Fakes file system modules for automated developer testing.'
 
 URL = "https://code.google.com/p/pyfakefs"
 
-readme = os.path.join(os.path.dirname(__file__), 'README')
+readme = os.path.join(os.path.dirname(__file__), 'README.md')
 LONG_DESCRIPTION = open(readme).read()
 
 CLASSIFIERS = [


### PR DESCRIPTION
Without this change, the setup.py build will result in


Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    LONG_DESCRIPTION = open(readme).read()
IOError: [Errno 2] No such file or directory: 'README'