### PR TITLE
Fix bug with calling rename with equal old & new names.

### DIFF
--- a/fake_filesystem.py
+++ b/fake_filesystem.py
@@ -1557,7 +1557,10 @@ class FakeOsModule(object):
                     'with name',
                     old_file)
     if self.filesystem.Exists(new_file):
-      self.remove(new_file)
+      if old_file == new_file:
+        return None  # Nothing to do here.
+      else:
+        self.remove(new_file)
     old_dir, old_name = self.path.split(old_file)
     new_dir, new_name = self.path.split(new_file)
     if not self.filesystem.Exists(new_dir):

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -929,6 +929,16 @@ class FakeOsModuleTest(TestCase):
     self.assertEqual(new_file.st_uid, old_file.st_uid)
     self.assertEqual(new_file.st_gid, old_file.st_gid)
 
+  def testRenameSameFilenames(self):
+    """Test renaming when old and new names are the same (regression test)."""
+    directory = 'xyzzy'
+    file_contents = 'Spam eggs'
+    file_path = '%s/eggs' % directory
+    self.filesystem.CreateFile(file_path, contents=file_contents)
+    self.os.rename(file_path, file_path)
+    self.assertEqual(file_contents,
+                     self.filesystem.GetObject(file_path).contents)
+
   def testRmdir(self):
     """Can remove a directory."""
     directory = 'xyzzy'


### PR DESCRIPTION
If you were to call rename() with the same values for both old name and new
name, GetEntry would raise an unnecesary KeyError. This commit fixes that.

Here's the traceback of the bug:

```
renamer.py:73: in run
    os.rename(i, o)
../.virtualenvs/renamer/lib/python2.7/site-packages/fake_filesystem.py:1566: in rename
    old_object = old_dir_object.GetEntry(old_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <fake_filesystem.FakeDirectory object at 0x6fffee1ce10>, pathname_name = 'eggs'

    def GetEntry(self, pathname_name):
      """Retrieves the specified child file or directory.

        Args:
          pathname_name: basename of the child object to retrieve
        Returns:
          string, file contents
        Raises:
          KeyError: if no child exists by the specified name
        """
>     return self.contents[pathname_name]
E     KeyError: u'eggs'

../.virtualenvs/renamer/lib/python2.7/site-packages/fake_filesystem.py:314: KeyError
```