### PR TITLE
Treat cygwin as a Windows

### DIFF
--- a/fake_filesystem.py
+++ b/fake_filesystem.py
@@ -126,9 +126,10 @@ FAKE_PATH_MODULE_DEPRECATION = ('Do not instantiate a FakePathModule directly; '
 class Error(Exception):
   pass
 
+is_windows = sys.platform.startswith('win') or sys.platform == 'cygwin'
 
-if sys.platform.startswith('win'):
-  # On Windows, raise WindowsError instead of OSError
+if is_windows and 'WindowsError' in globals():
+  # On Windows, raise WindowsError instead of OSError if available
   OSError = WindowsError  # pylint: disable-msg=E0602,W0622
 
 
@@ -1118,7 +1119,7 @@ class FakePathModule(object):
     """Normalize path, eliminating double slashes, etc."""
     return self.filesystem.CollapsePath(path)
 
-  if sys.platform.startswith('win'):
+  if is_windows:
 
     def relpath(self, path, start=None):
       """ntpath.relpath() needs the cwd passed in the start argument."""

--- a/fake_filesystem.py
+++ b/fake_filesystem.py
@@ -126,9 +126,10 @@ FAKE_PATH_MODULE_DEPRECATION = ('Do not instantiate a FakePathModule directly; '
 class Error(Exception):
   pass
 
-is_windows = sys.platform.startswith('win') or sys.platform == 'cygwin'
+_is_windows = sys.platform.startswith('win')
+_is_cygwin = sys.platform == 'cygwin'
 
-if is_windows and 'WindowsError' in globals():
+if _is_windows:
   # On Windows, raise WindowsError instead of OSError if available
   OSError = WindowsError  # pylint: disable-msg=E0602,W0622
 
@@ -1119,7 +1120,7 @@ class FakePathModule(object):
     """Normalize path, eliminating double slashes, etc."""
     return self.filesystem.CollapsePath(path)
 
-  if is_windows:
+  if _is_windows:
 
     def relpath(self, path, start=None):
       """ntpath.relpath() needs the cwd passed in the start argument."""

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -28,7 +28,6 @@ else:
     import unittest
 
 import fake_filesystem
-from fake_filesystem import is_windows
 
 
 def _GetDummyTime(start_time, increment):
@@ -40,6 +39,8 @@ def _GetDummyTime(start_time, increment):
 
 
 class TestCase(unittest.TestCase):
+  is_windows = sys.platform.startswith('win')
+  is_cygwin = sys.platform == 'cygwin'
 
   def assertModeEqual(self, expected, actual):
     return self.assertEqual(stat.S_IMODE(expected), stat.S_IMODE(actual))
@@ -1843,8 +1844,7 @@ class FakePathModuleTest(TestCase):
     self.assertEqual('.',
                      self.path.relpath(path_bar, path_bar))
 
-  @unittest.skipIf(is_windows,
-                   'realpath does not follow symlinks in win32')
+  @unittest.skipIf(TestCase.is_windows, 'realpath does not follow symlinks in win32')
   def testRealpathVsAbspath(self):
     self.filesystem.CreateFile('/george/washington/bridge')
     self.filesystem.CreateLink('/first/president', '/george/washington')
@@ -1880,12 +1880,16 @@ class FakePathModuleTest(TestCase):
     self.assertEqual('foo/bar/baz', self.path.join(*components))
 
   def testExpandUser(self):
-    if is_windows:
+    if self.is_windows:
       self.assertEqual(self.path.expanduser('~'),
                        self.os.environ['USERPROFILE'].replace('\\', '/'))
     else:
       self.assertEqual(self.path.expanduser('~'),
                        self.os.environ['HOME'])
+
+  @unittest.skipIf(TestCase.is_windows or TestCase.is_cygwin,
+                   'only tested on unix systems')
+  def testExpandRoot(self):
       self.assertEqual('/root', self.path.expanduser('~root'))
 
   def testGetsizePathNonexistent(self):
@@ -1969,7 +1973,7 @@ class FakePathModuleTest(TestCase):
 
     self.assertFalse(self.path.islink('it_dont_exist'))
 
-  @unittest.skipIf(sys.version_info >= (3, 0) or is_windows,
+  @unittest.skipIf(sys.version_info >= (3, 0) or TestCase.is_windows,
                    'os.path.walk deprecrated in Python 3, cannot be properly '
                    'tested in win32')
   def testWalk(self):
@@ -1987,7 +1991,7 @@ class FakePathModuleTest(TestCase):
                 ('/foo/bar/xyzzy', 'plugh')]
     self.assertEqual(expected, visited_nodes)
 
-  @unittest.skipIf(sys.version_info >= (3, 0) or is_windows,
+  @unittest.skipIf(sys.version_info >= (3, 0) or TestCase.is_windows,
                    'os.path.walk deprecrated in Python 3, cannot be properly '
                    'tested in win32')
   def testWalkFromNonexistentTopDoesNotThrow(self):

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -28,6 +28,7 @@ else:
     import unittest
 
 import fake_filesystem
+from fake_filesystem import is_windows
 
 
 def _GetDummyTime(start_time, increment):
@@ -1815,7 +1816,7 @@ class FakePathModuleTest(unittest.TestCase):
     self.assertEqual('.',
                      self.path.relpath(path_bar, path_bar))
 
-  @unittest.skipIf(sys.platform.startswith('win'),
+  @unittest.skipIf(is_windows,
                    'realpath does not follow symlinks in win32')
   def testRealpathVsAbspath(self):
     self.filesystem.CreateFile('/george/washington/bridge')
@@ -1852,7 +1853,7 @@ class FakePathModuleTest(unittest.TestCase):
     self.assertEqual('foo/bar/baz', self.path.join(*components))
 
   def testExpandUser(self):
-    if sys.platform.startswith('win'):
+    if is_windows:
       self.assertEqual(self.path.expanduser('~'),
                        self.os.environ['USERPROFILE'].replace('\\', '/'))
     else:
@@ -1941,7 +1942,7 @@ class FakePathModuleTest(unittest.TestCase):
 
     self.assertFalse(self.path.islink('it_dont_exist'))
 
-  @unittest.skipIf(sys.version_info >= (3, 0) or sys.platform.startswith('win'),
+  @unittest.skipIf(sys.version_info >= (3, 0) or is_windows,
                    'os.path.walk deprecrated in Python 3, cannot be properly '
                    'tested in win32')
   def testWalk(self):
@@ -1959,7 +1960,7 @@ class FakePathModuleTest(unittest.TestCase):
                 ('/foo/bar/xyzzy', 'plugh')]
     self.assertEqual(expected, visited_nodes)
 
-  @unittest.skipIf(sys.version_info >= (3, 0) or sys.platform.startswith('win'),
+  @unittest.skipIf(sys.version_info >= (3, 0) or is_windows,
                    'os.path.walk deprecrated in Python 3, cannot be properly '
                    'tested in win32')
   def testWalkFromNonexistentTopDoesNotThrow(self):

--- a/fake_filesystem_vs_real_test.py
+++ b/fake_filesystem_vs_real_test.py
@@ -31,6 +31,7 @@ else:
     import unittest
 
 import fake_filesystem
+from fake_filesystem import is_windows
 
 
 def Sep(path):
@@ -310,7 +311,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
 
     def assertAllOsBehaviorsMatch(self, path):
         path = Sep(path)
-        os_method_names = [] if sys.platform.startswith('win') else ['readlink']
+        os_method_names = [] if is_windows else ['readlink']
         os_method_names_no_args = ['getcwd']
         if sys.version_info < (3, 0):
             os_method_names_no_args.append('getcwdu')
@@ -319,7 +320,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
                                                         'isfile',
                                                         'exists'
                                                      ]
-        if not sys.platform.startswith('win'):
+        if not is_windows:
             os_path_method_names.append('islink')
             os_path_method_names.append('lexists')
         wrapped_methods = [['access', self._AccessReal, self._AccessFake],
@@ -444,31 +445,31 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('b', 'aFile', b'some contents')
         self.assertAllOsBehaviorsMatch('aFile')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testSymLinkToEmptyFile(self):
         self._CreateTestFile('f', 'aFile')
         self._CreateTestFile('l', 'link_to_empty', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_empty')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def TBD_testHardLinkToEmptyFile(self):
         self._CreateTestFile('f', 'aFile')
         self._CreateTestFile('h', 'link_to_empty', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_empty')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testSymLinkToRealFile(self):
         self._CreateTestFile('f', 'aFile', 'some contents')
         self._CreateTestFile('l', 'link_to_file', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_file')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def TBD_testHardLinkToRealFile(self):
         self._CreateTestFile('f', 'aFile', 'some contents')
         self._CreateTestFile('h', 'link_to_file', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_file')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testBrokenSymLink(self):
         self._CreateTestFile('l', 'broken_link', 'broken')
         self._CreateTestFile('l', 'loop', '/a/loop')
@@ -480,7 +481,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('f', 'a/b/file', 'contents')
         self.assertAllOsBehaviorsMatch('a/b/file')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testAbsoluteSymLinkToFolder(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -488,7 +489,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/link', '/a/b')
         self.assertAllOsBehaviorsMatch('a/link/file')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testLinkToFolderAfterChdir(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -500,7 +501,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self.fake_os.chdir(fake_dir)
         self.assertAllOsBehaviorsMatch('file')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testRelativeSymLinkToFolder(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -508,7 +509,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/link', 'b')
         self.assertAllOsBehaviorsMatch('a/link/file')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testSymLinkToParent(self):
         # Soft links on HFS+ / OS X behave differently.
         if os.uname()[0] != 'Darwin':
@@ -517,7 +518,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
             self._CreateTestFile('l', 'a/b/c', '..')
             self.assertAllOsBehaviorsMatch('a/b/c')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testPathThroughSymLinkToParent(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('f', 'a/target', 'contents')
@@ -525,7 +526,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/b/c', '..')
         self.assertAllOsBehaviorsMatch('a/b/c/target')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testSymLinkToSiblingDirectory(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -534,7 +535,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/b/c', '../sibling_of_b')
         self.assertAllOsBehaviorsMatch('a/b/c/target')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testSymLinkToSiblingDirectoryNonExistantFile(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -543,7 +544,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/b/c', '../sibling_of_b')
         self.assertAllOsBehaviorsMatch('a/b/c/file_does_not_exist')
 
-    @unittest.skipIf(sys.platform.startswith('win'), 'no symlink in Windows')
+    @unittest.skipIf(is_windows, 'no symlink in Windows')
     def testBrokenSymLinkToSiblingDirectory(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')

--- a/fake_filesystem_vs_real_test.py
+++ b/fake_filesystem_vs_real_test.py
@@ -31,7 +31,6 @@ else:
     import unittest
 
 import fake_filesystem
-from fake_filesystem import is_windows
 
 
 def Sep(path):
@@ -41,8 +40,13 @@ def Sep(path):
     return path
 
 
-class FakeFilesystemVsRealTest(unittest.TestCase):
+class TestCase(unittest.TestCase):
+    is_windows = sys.platform.startswith('win')
+    is_cygwin = sys.platform == 'cygwin'
     _FAKE_FS_BASE = Sep('/fakefs')
+
+
+class FakeFilesystemVsRealTest(TestCase):
 
     def _Paths(self, path):
         """For a given path, return paths in the real and fake filesystems."""
@@ -311,7 +315,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
 
     def assertAllOsBehaviorsMatch(self, path):
         path = Sep(path)
-        os_method_names = [] if is_windows else ['readlink']
+        os_method_names = [] if self.is_windows else ['readlink']
         os_method_names_no_args = ['getcwd']
         if sys.version_info < (3, 0):
             os_method_names_no_args.append('getcwdu')
@@ -320,7 +324,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
                                                         'isfile',
                                                         'exists'
                                                      ]
-        if not is_windows:
+        if not self.is_windows:
             os_path_method_names.append('islink')
             os_path_method_names.append('lexists')
         wrapped_methods = [['access', self._AccessReal, self._AccessFake],
@@ -445,31 +449,31 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('b', 'aFile', b'some contents')
         self.assertAllOsBehaviorsMatch('aFile')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testSymLinkToEmptyFile(self):
         self._CreateTestFile('f', 'aFile')
         self._CreateTestFile('l', 'link_to_empty', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_empty')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def TBD_testHardLinkToEmptyFile(self):
         self._CreateTestFile('f', 'aFile')
         self._CreateTestFile('h', 'link_to_empty', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_empty')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testSymLinkToRealFile(self):
         self._CreateTestFile('f', 'aFile', 'some contents')
         self._CreateTestFile('l', 'link_to_file', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_file')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def TBD_testHardLinkToRealFile(self):
         self._CreateTestFile('f', 'aFile', 'some contents')
         self._CreateTestFile('h', 'link_to_file', 'aFile')
         self.assertAllOsBehaviorsMatch('link_to_file')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testBrokenSymLink(self):
         self._CreateTestFile('l', 'broken_link', 'broken')
         self._CreateTestFile('l', 'loop', '/a/loop')
@@ -481,7 +485,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('f', 'a/b/file', 'contents')
         self.assertAllOsBehaviorsMatch('a/b/file')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testAbsoluteSymLinkToFolder(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -489,7 +493,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/link', '/a/b')
         self.assertAllOsBehaviorsMatch('a/link/file')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testLinkToFolderAfterChdir(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -501,7 +505,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self.fake_os.chdir(fake_dir)
         self.assertAllOsBehaviorsMatch('file')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testRelativeSymLinkToFolder(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -509,7 +513,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/link', 'b')
         self.assertAllOsBehaviorsMatch('a/link/file')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testSymLinkToParent(self):
         # Soft links on HFS+ / OS X behave differently.
         if os.uname()[0] != 'Darwin':
@@ -518,7 +522,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
             self._CreateTestFile('l', 'a/b/c', '..')
             self.assertAllOsBehaviorsMatch('a/b/c')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testPathThroughSymLinkToParent(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('f', 'a/target', 'contents')
@@ -526,7 +530,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/b/c', '..')
         self.assertAllOsBehaviorsMatch('a/b/c/target')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testSymLinkToSiblingDirectory(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -535,7 +539,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/b/c', '../sibling_of_b')
         self.assertAllOsBehaviorsMatch('a/b/c/target')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testSymLinkToSiblingDirectoryNonExistantFile(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')
@@ -544,7 +548,7 @@ class FakeFilesystemVsRealTest(unittest.TestCase):
         self._CreateTestFile('l', 'a/b/c', '../sibling_of_b')
         self.assertAllOsBehaviorsMatch('a/b/c/file_does_not_exist')
 
-    @unittest.skipIf(is_windows, 'no symlink in Windows')
+    @unittest.skipIf(TestCase.is_windows, 'no symlink in Windows')
     def testBrokenSymLinkToSiblingDirectory(self):
         self._CreateTestFile('d', 'a')
         self._CreateTestFile('d', 'a/b')


### PR DESCRIPTION
To be more specific, I had errors with `os.path.realpath`. As it turned out, cygwin wasn't recognized as a Windows and thas was causing the errors.

This commit should fix most of other undiscovered issues with cygwin.
Also, it's better to keep the critical logic of recognizing the system in a single place.