### PR TITLE
Protect binary data a little better

### DIFF
--- a/fake_filesystem.py
+++ b/fake_filesystem.py
@@ -161,9 +161,9 @@ class Hexlified(object):
 
   def recover(self, binary):
     if binary:
-      return binascii.unhexlify(self.contents)
+      return binascii.unhexlify(bytearray(self.contents, 'utf-8'))
     else:
-      return binascii.unhexlify(self.contents).decode(sys.getdefaultencoding())
+      return binascii.unhexlify(bytearray(self.contents, 'utf-8')).decode(sys.getdefaultencoding())
 
 
 class FakeFile(object):

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -2077,14 +2077,36 @@ class FakeFileOpenTest(FakeFileOpenTestBase):
     self.assertEqual(contents, text_fractions)
 
   @unittest.skipIf(sys.version_info >= (3, 0),
-                   'Does not work on Python3 per issue #63')
-  def testByteContents(self):
+                   'Python2-specific behavior')
+  def testByteContentsPy2(self):
     self.file = fake_filesystem.FakeFileOpen(self.filesystem)
     file_path = 'foo'
     byte_fractions = b'\xe2\x85\x93 \xe2\x85\x94 \xe2\x85\x95 \xe2\x85\x96'
     with self.file(file_path, 'w') as f:
       f.write(byte_fractions)
     with self.file(file_path) as f:
+      contents = f.read()
+    self.assertEqual(contents, byte_fractions)
+
+  @unittest.skipIf(sys.version_info < (3, 0),
+                   'Python3-specific behavior')
+  def testByteContentsPy3(self):
+    self.file = fake_filesystem.FakeFileOpen(self.filesystem)
+    file_path = 'foo'
+    byte_fractions = b'\xe2\x85\x93 \xe2\x85\x94 \xe2\x85\x95 \xe2\x85\x96'
+    with self.file(file_path, 'wb') as f:
+      f.write(byte_fractions)
+    with self.file(file_path) as f:
+      contents = f.read()
+    self.assertEqual(contents, byte_fractions.decode('utf-8'))
+
+  def testByteContents(self):
+    self.file = fake_filesystem.FakeFileOpen(self.filesystem)
+    file_path = 'foo'
+    byte_fractions = b'\xe2\x85\x93 \xe2\x85\x94 \xe2\x85\x95 \xe2\x85\x96'
+    with self.file(file_path, 'wb') as f:
+      f.write(byte_fractions)
+    with self.file(file_path, 'rb') as f:
       contents = f.read()
     self.assertEqual(contents, byte_fractions)
 

--- a/fake_tempfile_test.py
+++ b/fake_tempfile_test.py
@@ -123,7 +123,11 @@ class FakeTempfileModuleTest(unittest.TestCase):
     obj.write(b'foo')
     obj.close()
     file_obj = self.filesystem.GetObject(obj.name)
-    self.assertEqual('foo', file_obj.contents)
+    if sys.version_info >= (3, 0):
+        contents = file_obj.contents.recover(False)
+    else:
+        contents = file_obj.contents
+    self.assertEqual('foo', contents)
     obj = self.tempfile.NamedTemporaryFile(mode='w', delete=False)
     obj.write('foo')
     obj.close()


### PR DESCRIPTION
This also works for non-Unicode encodings (like compressed data).  

It fixes an expected behavior on Python 3 where reading strings from a binary file opened in non-binary mode will raise an exception.