### PR TITLE
Wrap file created by mkstemp

### DIFF
--- a/fake_tempfile_test.py
+++ b/fake_tempfile_test.py
@@ -64,6 +64,7 @@ class FakeTempfileModuleTest(unittest.TestCase):
 
   def setUp(self):
     self.filesystem = fake_filesystem.FakeFilesystem(path_separator='/')
+    self.os = fake_filesystem.FakeOsModule(self.filesystem)
     self.tempfile = fake_tempfile.FakeTempfileModule(self.filesystem)
     self.orig_logging = fake_tempfile.logging
     self.fake_logging = FakeLogging(self)
@@ -145,6 +146,8 @@ class FakeTempfileModuleTest(unittest.TestCase):
     self.assertTrue(self.filesystem.Exists(temporary[1]))
     self.assertEqual(self.filesystem.GetObject(temporary[1]).st_mode,
                      stat.S_IFREG|0o600)
+    fh = self.os.fdopen(temporary[0], 'w+b')
+    self.assertEqual(temporary[0], fh.fileno())
 
   def testMkstempDir(self):
     """test tempfile.mkstemp(dir=)."""

--- a/pyfakefs/fake_tempfile.py
+++ b/pyfakefs/fake_tempfile.py
@@ -192,8 +192,9 @@ class FakeTempfileModule(object):
     # default dir affected by "global"
     filename = self._TempEntryname(suffix, prefix, dir)
     fh = self._filesystem.CreateFile(filename, st_mode=stat.S_IFREG|0o600)
-    fd = self._filesystem.AddOpenFile(fh)
-
+    fh.opened_as = filename
+    fakefile = fake_filesystem.FakeFileWrapper(fh, filename)
+    fd = self._filesystem.AddOpenFile(fakefile)
     self._mktemp_retvals.append(filename)
     return (fd, filename)
 


### PR DESCRIPTION
This promotes the FakeFileWrapper class to top-level and has mkstemp wrap its file.  This lets fdopen() work properly.  This should address #23 (among other things).