### PR TITLE
Use proper checking for directory on open.

### DIFF
--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -2563,6 +2563,13 @@ class FakeFileOpenTest(FakeFileOpenTestBase):
     self.assertRaises(IOError, _IteratorOpen, file_path, 'w')
     self.assertRaises(IOError, _IteratorOpen, file_path, 'a')
 
+  def testCanReadFromBlockDevice(self):
+    device_path = 'device'
+    self.filesystem.CreateFile(device_path, stat.S_IFBLK 
+                               |fake_filesystem.PERM_ALL)
+    with self.open(device_path, 'r') as fh:
+      self.assertEqual('', fh.read())
+
 
 class OpenWithFileDescriptorTest(FakeFileOpenTestBase):
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1967,7 +1967,7 @@ class FakeFileOpen(object):
       file_object = self.filesystem.CreateFile(
           real_path, create_missing_dirs=False, apply_umask=True)
 
-    if file_object.st_mode & stat.S_IFDIR:
+    if stat.S_ISDIR(file_object.st_mode):
       raise IOError(errno.EISDIR, 'Fake file object: is a directory', file_path)
 
     class FakeFileWrapper(object):


### PR DESCRIPTION
So block devices aren't accidentally considered directories.  Should address #24.