### PR TITLE
Writes update mtime and float time support

### DIFF
--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -1400,10 +1400,11 @@ class FakeOsModuleTest(TestCase):
 
   def testUtimeSetsCurrentTimeIfArgsIsNoneWithFloats(self):
     # set up
-    # time.time can report back floats, but it should be converted to ints
-    # since atime/ctime/mtime are all defined as seconds since epoch.
+    # we set os.stat_float_times() to False, so atime/ctime/mtime
+    # are converted as ints (seconds since epoch)
     time.time = _GetDummyTime(200.0123, 20)
     path = '/some_file'
+    fake_filesystem.FakeOsModule.stat_float_times(False)
     self._CreateTestFile(path)
     st = self.os.stat(path)
     # 200 is the current time established above (if converted to int).
@@ -1416,8 +1417,10 @@ class FakeOsModuleTest(TestCase):
     self.assertEqual(240, st.st_mtime)
 
   def testUtimeSetsCurrentTimeIfArgsIsNoneWithFloatsNSec(self):
-    self.filesystem = fake_filesystem.FakeFilesystem(path_separator='/', nsec_stat=True)
+    self.filesystem = fake_filesystem.FakeFilesystem(path_separator='/')
     self.os = fake_filesystem.FakeOsModule(self.filesystem)
+    self.os.stat_float_times(True)
+    self.assertTrue(self.os.stat_float_times())
 
     time.time = _GetDummyTime(200.0123, 20)
     path = '/some_file'

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -198,8 +198,8 @@ class FakeFile(object):
     self.contents = contents
     self.epoch = 0
     self._st_ctime = time.time()    # times are accessed through properties
-    self._st_atime = self.st_ctime
-    self._st_mtime = self.st_ctime
+    self._st_atime = self._st_ctime
+    self._st_mtime = self._st_ctime
     if contents:
       self.st_size = len(contents)
     else:
@@ -275,7 +275,7 @@ class FakeFile(object):
       contents = Hexlified(contents)
 
     self.st_ctime = time.time()
-    self.st_mtime = self.st_ctime
+    self.st_mtime = self._st_ctime
     self.st_size = len(contents)
     self.contents = contents
     self.epoch += 1
@@ -1709,7 +1709,7 @@ class FakeOsModule(object):
       raise IOError(errno.ENOENT, 'No such fake directory', new_dir)
     old_dir_object = self.filesystem.ResolveObject(old_dir)
     old_object = old_dir_object.GetEntry(old_name)
-    old_object_mtime = old_object.st_mtime
+    old_object_mtime = old_object._st_mtime
     new_dir_object = self.filesystem.ResolveObject(new_dir)
     if old_object.st_mode & stat.S_IFDIR:
       old_object.name = new_name


### PR DESCRIPTION
mtime and ctime are updated during the SetContents() methods.
Removes a change to ctime that occurred just before that.

FakeFilesystem gets an `float_stat` option, that updates stat time
to the full precision of the time.time() call. The existing behavior,
using integers, is preserved as the default.