### PR TITLE
Some drive-letter related fixes

### DIFF
--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -1965,6 +1965,13 @@ class FakePathModuleTest(TestCase):
     self.assertEqual(self.path.join(basedir, file_components[1]),
                      self.path.abspath(file_components[1]))
 
+  def testAbsPathWithDriveComponent(self):
+    self.filesystem.supports_drive_letter = True
+    self.filesystem.cwd = 'C:/foo'
+    self.assertEqual('C:/foo/bar', self.path.abspath('bar'))
+    self.assertEqual('C:/foo/bar', self.path.abspath('C:bar'))
+    self.assertEqual('C:/foo/bar', self.path.abspath('/foo/bar'))
+
   def testRelpath(self):
     path_foo = '/path/to/foo'
     path_bar = '/path/to/bar'
@@ -3274,11 +3281,20 @@ class DriveLetterSupportTest(TestCase):
     self.assertEqual(('c:/foo', 'bar'), self.filesystem.SplitPath('c:/foo/bar'))
 
   def testCharactersBeforeRootIgnoredInJoinPaths(self):
-    self.assertEqual('c:/d', self.filesystem.JoinPaths('b', 'c:', 'd'))
+    self.assertEqual('c:d', self.filesystem.JoinPaths('b', 'c:', 'd'))
 
   def testResolvePath(self):
     self.assertEqual('c:/foo/bar', self.filesystem.ResolvePath('c:/foo/bar'))
 
+  def testGetPathComponents(self):
+    self.assertEqual(['c:', 'foo', 'bar'], self.filesystem.GetPathComponents('c:/foo/bar'))
+    self.assertEqual(['c:'], self.filesystem.GetPathComponents('c:'))
+
+  def testSplitDrive(self):
+    self.assertEqual(('c:', '/foo/bar'), self.filesystem.SplitDrive('c:/foo/bar'))
+    self.assertEqual(('', '/foo/bar'), self.filesystem.SplitDrive('/foo/bar'))
+    self.assertEqual(('c:', 'foo/bar'), self.filesystem.SplitDrive('c:foo/bar'))
+    self.assertEqual(('', 'foo/bar'), self.filesystem.SplitDrive('foo/bar'))
 
 class DiskSpaceTest(TestCase):
   def setUp(self):

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -685,6 +685,45 @@ class FakeFilesystem(object):
     # Root path.  Collapse all leading separators.
     return (self.path_separator, basename)
 
+  def SplitDrive(self, path):
+    """Splits the path into the drive part and the rest of the path, if if drive letters are supported,
+       and a drive is presnt, otherwise returns an empty string and the original path.
+    """
+    if self.supports_drive_letter:
+      if len(path) >= 2:
+          path = self.NormalizePathSeparator(path)
+          if path[1] == ':':
+              return path[:2], path[2:]
+    return path[:0], path
+
+  def _JoinPathsWithDriveSupport(self, *all_paths):
+    """Taken from Python 3.5 os.path.join() code in ntpath.py and slightly adapted"""
+    path = all_paths[0]
+    paths = all_paths[1:]
+    seps = [self.path_separator, self.alternative_path_separator]
+    result_drive, result_path = self.SplitDrive(path)
+    for p in paths:
+      p_drive, p_path = self.SplitDrive(p)
+      if p_path and p_path[0] in seps:
+        # Second path is absolute
+        if p_drive or not result_drive:
+            result_drive = p_drive
+        result_path = p_path
+        continue
+      elif p_drive and p_drive != result_drive:
+          if not self.is_case_sensitive and p_drive.lower() != result_drive.lower():
+              # Different drives => ignore the first path entirely
+              result_drive = p_drive
+              result_path = p_path
+              continue
+          # Same drive in different case
+          result_drive = p_drive
+      # Second path is relative to the first
+      if result_path and result_path[-1] not in seps:
+          result_path = result_path + self.path_separator
+      result_path = result_path + p_path
+    return result_drive + result_path
+
   def JoinPaths(self, *paths):
     """Mimics os.path.join using the specified path_separator.
 
@@ -700,6 +739,8 @@ class FakeFilesystem(object):
     """
     if len(paths) == 1:
       return paths[0]
+    if self.supports_drive_letter:
+      return self._JoinPathsWithDriveSupport(*paths)
     joined_path_segments = []
     for path_segment in paths:
       if self._StartsWithRootPath(path_segment):
@@ -735,7 +776,7 @@ class FakeFilesystem(object):
     Returns:
       The list of names split from path
     """
-    if not path or self._IsRootPath(path):
+    if not path or path == self.path_separator:
       return []
     path_components = path.split(self.path_separator)
     assert path_components
@@ -744,15 +785,23 @@ class FakeFilesystem(object):
       path_components = path_components[1:]
     return path_components
 
+  def _StartsWithDriveLetter(self, file_path):
+    return self.supports_drive_letter and len(file_path) >= 2 and file_path[0].isalpha and file_path[1] == ':'
+
   def _StartsWithRootPath(self, file_path):
     return (file_path.startswith(self.root.name) or
             not self.is_case_sensitive and file_path.lower().startswith(self.root.name.lower()) or
-            self.supports_drive_letter and len(file_path) >= 2 and file_path[0].isalpha and file_path[1] == ':')
+            self._StartsWithDriveLetter(file_path))
 
   def _IsRootPath(self, file_path):
     return (file_path == self.root.name or
             not self.is_case_sensitive and file_path.lower() == self.root.name.lower() or
-            self.supports_drive_letter and len(file_path) == 2 and file_path[0].isalpha and file_path[1] == ':')
+            len(file_path) == 2 and self._StartsWithDriveLetter(file_path))
+
+  def _EndsWithPathSeparator(self, file_path):
+    return file_path and (file_path.endswith(self.path_separator)
+                          or self.alternative_path_separator is not None
+                          and file_path.endswith(self.alternative_path_separator))
 
   def _DirectoryContent(self, directory, component):
     if component in directory.contents:
@@ -1310,17 +1359,28 @@ class FakePathModule(object):
 
   def abspath(self, path):
     """Return the absolute version of a path."""
-    if not self.isabs(path):
+    def getcwd():
       if sys.version_info < (3, 0) and isinstance(path, unicode):
-        cwd = self.os.getcwdu()
+        return self.os.getcwdu()
       else:
-        cwd = self.os.getcwd()
-      path = self.join(cwd, path)
+        return self.os.getcwd()
+
+    if not self.isabs(path):
+      path = self.join(getcwd(), path)
+    elif (self.filesystem.supports_drive_letter and
+        path.startswith(self.sep) or self.altsep is not None and path.startswith(self.altsep)):
+      cwd = getcwd()
+      if self.filesystem._StartsWithDriveLetter(cwd):
+        path = self.join(cwd[:2], path)
     return self.normpath(path)
 
   def join(self, *p):
     """Returns the completed path with a separator of the parts."""
     return self.filesystem.JoinPaths(*p)
+
+  def splitpath(self, path):
+    """Splits the path into the drive part and the rest of the path, if supported."""
+    return self.filesystem.SplitDrive(path)
 
   def normpath(self, path):
     """Normalize path, eliminating double slashes, etc."""
@@ -1878,7 +1938,7 @@ class FakeOsModule(object):
       OSError: if the directory name is invalid or parent directory is read only
       or as per FakeFilesystem.AddObject.
     """
-    if dir_name.endswith(self.sep):
+    if self.filesystem._EndsWithPathSeparator(dir_name):
       dir_name = dir_name[:-1]
 
     parent_dir, _ = self.path.split(dir_name)


### PR DESCRIPTION
- use adapted Windows specific Python join() with drive letter support
- fixed abspath() wih regard to drive letters
- fixed previously introduced bug in GetPathComponents()
- implemented splitdrive() to be able to test it under Linux