### PR TITLE
Drive letter handling fix

### DIFF
--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -3290,6 +3290,7 @@ class DriveLetterSupportTest(TestCase):
 
   def testSplitPath(self):
     self.assertEqual(('c:/foo', 'bar'), self.filesystem.SplitPath('c:/foo/bar'))
+    self.assertEqual(('c:', 'foo'), self.filesystem.SplitPath('c:/foo'))
 
   def testCharactersBeforeRootIgnoredInJoinPaths(self):
     self.assertEqual('c:d', self.filesystem.JoinPaths('b', 'c:', 'd'))

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -687,7 +687,7 @@ class FakeFilesystem(object):
           path_components.pop()
         return (drive + self.path_separator.join(path_components), basename)
     # Root path.  Collapse all leading separators.
-    return (drive + self.path_separator, basename)
+    return (drive or self.path_separator, basename)
 
   def SplitDrive(self, path):
     """Splits the path into the drive part and the rest of the path, if drive letters are supported


### PR DESCRIPTION
- correctly handle drive root in SplitPath() (hopefully last fix )