### PR TITLE
Update tests to pass on OSX; update README to claim OSX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ See [Travis-CI](http://travis-ci.org) for
 ## Installation
 
 ### Compatibility
-pyfakefs works with Python 2.6 and above, on Linux and Windows.  pyfakefs requires [mox3](https://pypi.python.org/pypi/mox3).
+pyfakefs works with Python 2.6 and above, on Linux, Windows and OSX (MacOS).
+pyfakefs requires [mox3](https://pypi.python.org/pypi/mox3).
 
 When using pyfakefs with [PyTest](doc.pytest.org), Pytest version 2.8.6 or above is required.
 

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -2370,7 +2370,11 @@ class FakePathModuleTest(TestCase):
     @unittest.skipIf(TestCase.is_windows or TestCase.is_cygwin,
                      'only tested on unix systems')
     def testExpandRoot(self):
-        self.assertEqual('/root', self.path.expanduser('~root'))
+        if sys.platform == 'darwin':
+            roothome = '/var/root'
+        else:
+            roothome = '/root'
+        self.assertEqual(self.path.expanduser('~root'), roothome)
 
     def testGetsizePathNonexistent(self):
         file_path = 'foo/bar/baz'


### PR DESCRIPTION
The only change I made here is to recognize in the tests that on OSX ~root
is /var/root instead of /root.

setup.py has claimed OSX support all along, which is basically true.

@mrbean-bremen, sanity check, please.