### PR TITLE
Improved support for Windows file system tests

### DIFF
--- a/fake_filesystem_shutil_test.py
+++ b/fake_filesystem_shutil_test.py
@@ -51,8 +51,17 @@ class FakeShutilModuleTest(unittest.TestCase):
         self.assertRaises(OSError, self.shutil.rmtree, '/foo')
         self.assertTrue(self.filesystem.Exists('/foo/baz'))
 
-    @unittest.skipIf(sys.platform != 'win32', 'Open files cannot be removed under Windows')
+    def testRmtreeWithOpenFilePosix(self):
+        self.filesystem.is_windows_fs = False
+        fake_open = fake_filesystem.FakeFileOpen(self.filesystem)
+        self.filesystem.CreateFile('/foo/bar')
+        self.filesystem.CreateFile('/foo/baz')
+        fake_open('/foo/baz', 'r')
+        self.shutil.rmtree('/foo')
+        self.assertFalse(self.filesystem.Exists('/foo/baz'))
+
     def testRmtreeWithOpenFileFailsUnderWindows(self):
+        self.filesystem.is_windows_fs = True
         fake_open = fake_filesystem.FakeFileOpen(self.filesystem)
         self.filesystem.CreateFile('/foo/bar')
         self.filesystem.CreateFile('/foo/baz')

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -959,30 +959,27 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.filesystem.is_windows_fs = False
         self.checkReadlinkRaisesIfPathIsNotALink()
 
-    @unittest.skipIf(TestCase.is_windows and sys.version_info < (3, 3),
-                     'Links are not supported under Windows before Python 3.3')
-    def checkReadlinkRaisesIfPathHasFile(self):
-        self.filesystem.is_windows_fs = False
+    def checkReadlinkRaisesIfPathHasFile(self, error_subtype):
         self.filesystem.CreateFile('/a_file')
         file_path = '/a_file/foo'
-        self.assertRaisesIOError(errno.ENOTDIR, self.os.readlink, file_path)
+        self.assertRaisesOSError(error_subtype, self.os.readlink, file_path)
         file_path = '/a_file/foo/bar'
-        self.assertRaisesIOError(errno.ENOTDIR, self.os.readlink, file_path)
+        self.assertRaisesOSError(error_subtype, self.os.readlink, file_path)
 
-    @unittest.skipIf(TestCase.is_windows and sys.version_info < (3, 3),
+    @unittest.skipIf(sys.version_info < (3, 3),
                      'Links are not supported under Windows before Python 3.3')
     def testReadlinkRaisesIfPathHasFileWindows(self):
-        self.filesystem.is_windows_fs = False
-        self.checkReadlinkRaisesIfPathHasFile()
+        self.filesystem.is_windows_fs = True
+        self.checkReadlinkRaisesIfPathHasFile(errno.ENOENT)
 
     def testReadlinkRaisesIfPathHasFilePosix(self):
-        self.filesystem.is_windows_fs = True
-        self.checkReadlinkRaisesIfPathHasFile()
+        self.filesystem.is_windows_fs = False
+        self.checkReadlinkRaisesIfPathHasFile(errno.ENOTDIR)
 
-    @unittest.skipIf(TestCase.is_windows and sys.version_info < (3, 3),
+    @unittest.skipIf(sys.version_info < (3, 3),
                      'Links are not supported under Windows before Python 3.3')
     def testReadlinkRaisesIfPathDoesNotExist(self):
-        self.assertRaisesIOError(errno.ENOENT, self.os.readlink, '/this/path/does/not/exist')
+        self.assertRaisesOSError(errno.ENOENT, self.os.readlink, '/this/path/does/not/exist')
 
     @unittest.skipIf(TestCase.is_windows and sys.version_info < (3, 3),
                      'Links are not supported under Windows before Python 3.3')
@@ -1142,8 +1139,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         old_path = '/foo/bar'
         new_path = '/mount/bar'
         self.filesystem.CreateFile(old_path)
-        self.filesystem.CreateFile(new_path)
-        self.assertRaisesOSError(errno.EEXIST, self.os.rename, old_path, new_path)
+        self.assertRaisesOSError(errno.EXDEV, self.os.rename, old_path, new_path)
 
     def testRenameToExistentFilePosix(self):
         """Can rename a file to a used name under Unix."""

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -57,13 +57,11 @@ class TestCase(unittest.TestCase):
     def assertRaisesOSError(self, subtype, expression, *args, **kwargs):
         try:
             expression(*args, **kwargs)
-        except WindowsError as exc:
-            if sys.version_info < (3, 0):
+        except OSError as exc:
+            if self.is_windows and sys.version_info < (3, 0):
                 self.assertEqual(exc.winerror, subtype)
             else:
                 self.assertEqual(exc.errno, subtype)
-        except OSError as exc:
-            self.assertEqual(exc.errno, subtype)
 
 
 class FakeDirectoryUnitTest(TestCase):

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -134,7 +134,7 @@ class _FakeFlavour(pathlib._Flavour):
         self.filesystem = filesystem
         self.sep = filesystem.path_separator
         self.altsep = filesystem.alternative_path_separator
-        self.has_drv = filesystem.supports_drive_letter
+        self.has_drv = filesystem.is_windows_fs
         super(_FakeFlavour, self).__init__()
 
     @staticmethod
@@ -202,7 +202,7 @@ class _FakeFlavour(pathlib._Flavour):
         """Split path into drive, root and rest."""
         if sep is None:
             sep = self.filesystem.path_separator
-        if self.filesystem.supports_drive_letter:
+        if self.filesystem.is_windows_fs:
             return self._splitroot_with_drive(path, sep)
         return self._splitroot_posix(path, sep)
 
@@ -291,7 +291,7 @@ class _FakeFlavour(pathlib._Flavour):
 
     def resolve(self, path, strict):
         """Make the path absolute, resolving any symlinks."""
-        if self.filesystem.supports_drive_letter:
+        if self.filesystem.is_windows_fs:
             return self._resolve_windows(path, strict)
         else:
             return self._resolve_posix(path, strict)
@@ -332,7 +332,7 @@ class _FakeWindowsFlavour(_FakeFlavour):
         # not considered reserved by Windows.
         if not parts:
             return False
-        if self.filesystem.supports_drive_letter and parts[0].startswith('\\\\'):
+        if self.filesystem.is_windows_fs and parts[0].startswith('\\\\'):
             # UNC paths are never reserved
             return False
         return parts[-1].partition('.')[0].upper() in self.reserved_names


### PR DESCRIPTION
- renamed supports_drive_letter to is_windows_fs and use it for more Windows-specific stuff to be able to run more tests for Windows fs under Linux
- added Windows/Posix variants for some tests that ran only under one system before
- test for raised OSError subtypes 
- faek_pathlib_test: used uncommon path separator to ensure usage of fake filesystem
- use SplitPath instead of os.path.split in RenameObject()
