### PR TITLE
os.listdir sometime returns a dict instead of a list

### DIFF
--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -745,7 +745,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         files.sort()
         self.assertEqual(files, sorted(self.os.listdir(directory)))
 
-    def testListdirDictionnary(self):
+    def testListdirReturnsList(self):
         directory_root = 'xyzzy'
         self.os.mkdir(directory_root)
         directory = '%s/bug' % directory_root

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -745,6 +745,14 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         files.sort()
         self.assertEqual(files, sorted(self.os.listdir(directory)))
 
+    def testListdirDictionnary(self):
+        directory_root = 'xyzzy'
+        self.os.mkdir(directory_root)
+        directory = '%s/bug' % directory_root
+        self.os.mkdir(directory)
+        self.filesystem.CreateFile('%s/%s' % (directory, 'foo'))
+        self.assertEqual(['foo'], self.os.listdir(directory))
+
     @unittest.skipIf(TestCase.is_windows and sys.version_info < (3, 3),
                      'Links are not supported under Windows before Python 3.3')
     def testListdirOnSymlink(self):

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1973,9 +1973,7 @@ class FakeFilesystem(object):
         target_directory = self.ResolvePath(target_directory)
         directory = self.ConfirmDir(target_directory)
         directory_contents = directory.contents
-        if isinstance(directory_contents, dict):
-            return list(directory_contents.keys())
-        return directory_contents
+        return list(directory_contents.keys())
 
     if sys.version_info >= (3, 5):
         class DirEntry():

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1972,7 +1972,10 @@ class FakeFilesystem(object):
         """
         target_directory = self.ResolvePath(target_directory)
         directory = self.ConfirmDir(target_directory)
-        return directory.contents
+        directory_contents = directory.contents
+        if isinstance(directory_contents, dict):
+            return list(directory_contents.keys())
+        return directory_contents
 
     if sys.version_info >= (3, 5):
         class DirEntry():


### PR DESCRIPTION
Hi,

I found a bug on the os.listdir expected behaviour in python 3.5 (I'm migrating a project from 2.7 to 3.5).

os.listdir on a fake directory returns a dictionnary instead of a list.

I fixed it in the pull request by returning the list of keys if it's a dictionnary. Maybe not the best but I don't know the library enought to dig further.

Kind Regards,
Alexis