### PR TITLE
Fix shutil.move implementation

### DIFF
--- a/fake_filesystem_shutil_test.py
+++ b/fake_filesystem_shutil_test.py
@@ -273,8 +273,8 @@ class FakeShutilModuleTest(unittest.TestCase):
         self.assertFalse(self.filesystem.Exists(dst_directory))
         self.shutil.move(src_directory, dst_directory)
         self.assertTrue(self.filesystem.Exists(dst_directory))
-        self.assertTrue(self.filesystem.Exists('%s/subfile' % dst_directory))
-        self.assertTrue(self.filesystem.Exists('%s/subdir' % dst_directory))
+        self.assertTrue(self.filesystem.Exists('%s/%s/subfile' % (dst_directory, src_directory)))
+        self.assertTrue(self.filesystem.Exists('%s/%s/subdir' % (dst_directory, src_directory)))
         self.assertFalse(self.filesystem.Exists(src_directory))
 
     @unittest.skipIf(sys.version_info < (3, 3), 'New in Python 3.3')

--- a/pyfakefs/fake_filesystem_shutil.py
+++ b/pyfakefs/fake_filesystem_shutil.py
@@ -285,8 +285,10 @@ class FakeShutilModule(object):
             return dst
 
         source_is_dir = stat.S_ISDIR(self.filesystem.GetObject(src).st_mode)
-        if source_is_dir and self.filesystem.Exists(dst):
-            raise shutil.Error("Destination path '%s' already exists" % dst)
+        if source_is_dir:
+            dst = self.filesystem.JoinPaths(dst, os.path.basename(src))
+            if self.filesystem.Exists(dst):
+                raise shutil.Error("Destination path '%s' already exists" % dst)
 
         try:
             self.filesystem.RenameObject(src, dst)


### PR DESCRIPTION
If both the source and destination argument of shutil.move are
directories the source directory is copied under the target directory.
pyfakefs implementation copied the source directory to the target
directory.

The real shutil.move call shutil.copy('/path/to/src', '/path/to/dest')
moves /path/to/src to /path/to/dest/src but the pyfakefs implementation
moved the src directory to /path/to/dest