### PR TITLE
Fix disk usage calculations when too large file is created

### DIFF
--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -308,10 +308,10 @@ class FakeFile(object):
         if self.byte_contents:
             self.SetSize(0)
         current_size = self.st_size or 0
+        if self.filesystem:
+            self.filesystem.ChangeDiskUsage(st_size - current_size, self.name, self.st_dev)
         self.byte_contents = contents
         self.st_size = st_size
-        if self.filesystem:
-            self.filesystem.ChangeDiskUsage(self.st_size - current_size, self.name, self.st_dev)
         self.epoch += 1
 
     def SetContents(self, contents, encoding=None):


### PR DESCRIPTION
Previously if you created file having larger initial contents than the
free space in the fake filesystem, the disk usage counter was decreased
by the size of the initial contents possibly resulting in negative usage.

Basically the issue was that when ChangeDiskUsage is called with size
larger than the amount of free space, space usage is not changed but
an error is raised. Due to an exception, CreateFile removes the created
object that results in new call to ChangeDiskUsage with negative size
of the object.

Previously the object's size was set before ChangeDiskUsage was called
and then when the object was being removed the object's already set size
was used to reduce the filesystem usage (even though that size was never
added to the usage).