### PR TITLE
Added helper method fake_filesystem_unittest.TestCase.copyRealFile()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ The release versions are PyPi releases.
 
 ## Version 3.1 (as yet unreleased)
 
+ * Added helper method `FakeFile.CopyRealFile()` to copy a file from \
+   the real file system to the fake file system.  This makes it easy to use \
+   files from the real file system in your tests.
 
 ## Version 3.0
 

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -463,33 +463,6 @@ class FakeFilesystemUnitTest(TestCase):
         self.filesystem.CreateFile(path, contents='dummy_data')
         self.assertRaises(IOError, self.filesystem.CreateFile, path)
 
-    def testCopyRealFile(self):
-        '''Copy real file to fake file system'''
-        real_file_path = __file__
-        fake_file_path = 'foo/bar/baz'
-        fake_file = self.filesystem.CopyRealFile(real_file_path, fake_file_path)
-        
-        real_stat = os.stat(real_file_path)
-        with open(real_file_path, 'rb') as real_file:
-            real_contents = real_file.read()
-        self.assertEqual(fake_file.name, 'baz')
-        self.assertEqual(fake_file.st_mode, real_stat.st_mode)
-        self.assertEqual(fake_file.byte_contents, real_contents)
-        self.assertEqual(fake_file.st_size, real_stat.st_size)
-        self.assertEqual(fake_file.st_ctime, real_stat.st_ctime)
-        self.assertEqual(fake_file.st_atime, real_stat.st_atime)
-        self.assertEqual(fake_file.st_mtime, real_stat.st_mtime)
-        self.assertEqual(fake_file.st_nlink, real_stat.st_nlink)
-        # The inode number is not copied to the fake file.
-        self.assertEqual(fake_file.st_dev, real_stat.st_dev)
-        self.assertEqual(fake_file.st_uid, real_stat.st_uid)
-        self.assertEqual(fake_file.st_gid, real_stat.st_gid)
-
-        fake_file_path = '/nonexistent/directory/file'
-        with self.assertRaises(IOError):
-            self.filesystem.CopyRealFile(real_file_path, fake_file_path,
-                                         create_missing_dirs=False)
-
     @unittest.skipIf(TestCase.is_windows and sys.version_info < (3, 3),
                      'Links are not supported under Windows before Python 3.3')
     def testCreateLink(self):

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -172,25 +172,29 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
 
     @classmethod
     def setUpClass(cls):
-        with open(__file__, 'rb') as f:
-            cls.real_byte_contents = f.read()
+        if sys.version_info >= (2, 7):
+            with open(__file__, 'rb') as f:
+                cls.real_byte_contents = f.read()
         with open(__file__) as f:
             cls.real_string_contents = f.read()
         cls.real_stat = os.stat(__file__)
 
     def testCopyRealFile(self):
         '''Copy a real file to the fake file system'''
-        self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
-                        'Verify byte contents of real file')
-        self.assertTrue('class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_string_contents,
-                        'Verify string contents of real file')
         # Use this file as the file to be copied to the fake file system
         real_file_path = __file__
         fake_file_path = 'foo/bar/baz'
         fake_file = self.CopyRealFile(real_file_path, fake_file_path)
 
-        self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
+        if sys.version_info >= (2, 7):
+            self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
+                            'Verify real file byte contents')
+            self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
+
+        self.assertTrue('class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_string_contents,
+                        'Verify real file string contents')
         self.assertEqual(fake_file.contents, self.real_string_contents)
+
         self.assertEqual(fake_file.name, 'baz')
         self.assertEqual(fake_file.st_mode, self.real_stat.st_mode)
         self.assertEqual(fake_file.byte_contents, self.real_byte_contents)

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 #
 # Copyright 2014 Altera Corporation. All Rights Reserved.
+# Copyright 2015-2017 John McGehee
 # Author: John McGehee
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,10 +40,6 @@ class TestPyfakefsUnittestBase(fake_filesystem_unittest.TestCase):
     def setUp(self):
         """Set up the fake file system"""
         self.setUpPyfakefs()
-
-    def tearDown(self):
-        """Tear down the fake file system"""
-        self.tearDownPyfakefs()
 
 
 class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
@@ -169,6 +166,45 @@ class TestPatchPathUnittestPassing(TestPyfakefsUnittestBase):
     def test_own_path_module(self):
         self.assertEqual(2, path.floor(2.5))
 
+
+class TestCopyRealFile(TestPyfakefsUnittestBase):
+    """Tests the `fake_filesystem_unittest.TestCase.CopyRealFile()` method."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(__file__, 'rb') as f:
+            cls.real_byte_contents = f.read()
+        with open(__file__) as f:
+            cls.real_string_contents = f.read()
+        cls.real_stat = os.stat(__file__)
+
+    def testCopyRealFile(self):
+        '''Copy a real file to the fake file system'''
+        self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
+                        'Verify byte contents of real file')
+        self.assertTrue('class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_string_contents,
+                        'Verify string contents of real file')
+        # Use this file as the file to be copied to the fake file system
+        real_file_path = __file__
+        fake_file_path = 'foo/bar/baz'
+        fake_file = self.CopyRealFile(real_file_path, fake_file_path)
+
+        self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
+        self.assertEqual(fake_file.contents, self.real_string_contents)
+        self.assertEqual(fake_file.name, 'baz')
+        self.assertEqual(fake_file.st_mode, self.real_stat.st_mode)
+        self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
+        self.assertEqual(fake_file.st_size, self.real_stat.st_size)
+        self.assertEqual(fake_file.st_ctime, self.real_stat.st_ctime)
+        self.assertEqual(fake_file.st_atime, self.real_stat.st_atime)
+        self.assertEqual(fake_file.st_mtime, self.real_stat.st_mtime)
+        self.assertEqual(fake_file.st_uid, self.real_stat.st_uid)
+        self.assertEqual(fake_file.st_gid, self.real_stat.st_gid)
+
+        fake_file_path = '/nonexistent/directory/file'
+        with self.assertRaises(IOError):
+            self.CopyRealFile(real_file_path, fake_file_path,
+                              create_missing_dirs=False)
 
 if __name__ == "__main__":
     unittest.main()

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -169,7 +169,7 @@ class TestPatchPathUnittestPassing(TestPyfakefsUnittestBase):
 
 @unittest.skipIf(sys.version_info < (2, 7), "No byte strings in Python 2.6")
 class TestCopyRealFile(TestPyfakefsUnittestBase):
-    """Tests the `fake_filesystem_unittest.TestCase.CopyRealFile()` method."""
+    """Tests the `fake_filesystem_unittest.TestCase.copyRealFile()` method."""
 
     @classmethod
     def setUpClass(cls):
@@ -184,7 +184,7 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
         # Use this file as the file to be copied to the fake file system
         real_file_path = __file__
         fake_file_path = 'foo/bar/baz'
-        fake_file = self.CopyRealFile(real_file_path, fake_file_path)
+        fake_file = self.copyRealFile(real_file_path, fake_file_path)
 
         self.assertTrue('class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_string_contents,
                         'Verify real file string contents')
@@ -203,7 +203,7 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
 
         fake_file_path = '/nonexistent/directory/file'
         with self.assertRaises(IOError):
-            self.CopyRealFile(real_file_path, fake_file_path,
+            self.copyRealFile(real_file_path, fake_file_path,
                               create_missing_dirs=False)
 
 

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -167,6 +167,7 @@ class TestPatchPathUnittestPassing(TestPyfakefsUnittestBase):
         self.assertEqual(2, path.floor(2.5))
 
 
+@unittest.skipIf(sys.version_info < (2, 7), "No byte strings in Python 2.6")
 class TestCopyRealFile(TestPyfakefsUnittestBase):
     """Tests the `fake_filesystem_unittest.TestCase.CopyRealFile()` method."""
 
@@ -187,7 +188,10 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
 
         self.assertTrue('class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_string_contents,
                         'Verify real file string contents')
+        self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
+                        'Verify real file byte contents')
         self.assertEqual(fake_file.contents, self.real_string_contents)
+        self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
 
         self.assertEqual(fake_file.st_mode, self.real_stat.st_mode)
         self.assertEqual(fake_file.st_size, self.real_stat.st_size)
@@ -202,17 +206,6 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
             self.CopyRealFile(real_file_path, fake_file_path,
                               create_missing_dirs=False)
 
-    @unittest.skipIf(sys.version_info < (2, 7), "No byte strings in Python 2.6")
-    def testCopyRealFileByteContents(self):
-        '''Copy a byte real file to the fake file system'''
-        # Use this file as the file to be copied to the fake file system
-        real_file_path = __file__
-        fake_file_path = 'foo/bar/baz'
-        fake_file = self.CopyRealFile(real_file_path, fake_file_path)
-
-        self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
-                        'Verify real file byte contents')
-        self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1635,41 +1635,6 @@ class FakeFilesystem(object):
 
         return file_object
 
-    def CopyRealFile(self, real_file_path, fake_file_path,
-                     create_missing_dirs=True):
-        """Copy the specified file from the real file system to the fake file
-        system.  With the exception of inode, the stat (permissions, modification
-        time, etc.) of the source file is copied to the new fake file.
-
-        This helper method can be used to set up tests more easily.
-
-        Args:
-          real_file_path: Path to the source file in the real file system.
-          fake_file_path: path to the destination file in the fake file system.
-          create_missing_dirs: if True, auto create missing directories.
-
-        Returns:
-          the newly created FakeFile object.
-
-        Raises:
-          IOError: if the file already exists.
-          IOError: if the containing directory is required but missing.
-        """
-        real_stat = os.stat(real_file_path)
-        with open(real_file_path, 'rb') as real_file:
-            real_contents = real_file.read()
-        file_object = self.CreateFile(fake_file_path, st_mode=real_stat.st_mode,
-                                    contents=real_contents,
-                                    create_missing_dirs=create_missing_dirs)
-        file_object.st_ctime = real_stat.st_ctime
-        file_object.st_atime = real_stat.st_atime
-        file_object.st_mtime = real_stat.st_mtime
-        file_object.st_nlink = real_stat.st_nlink
-        file_object.st_dev = real_stat.st_dev
-        file_object.st_gid = real_stat.st_gid
-        file_object.st_uid = real_stat.st_uid
-        return file_object
-
     # pylint: disable=unused-argument
     def CreateLink(self, file_path, link_target, target_is_directory=False):
         """Create the specified symlink, pointed at the specified link target.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1582,7 +1582,7 @@ class FakeFilesystem(object):
                    apply_umask=False, encoding=None):
         """Create file_path, including all the parent directories along the way.
 
-        Helper method to set up your test faster.
+        This helper method can be used to set up tests more easily.
 
         Args:
           file_path: path to the file to create.
@@ -1633,6 +1633,41 @@ class FakeFilesystem(object):
                 self.RemoveObject(file_path)
                 raise
 
+        return file_object
+
+    def CopyRealFile(self, real_file_path, fake_file_path,
+                     create_missing_dirs=True):
+        """Copy the specified file from the real file system to the fake file
+        system.  With the exception of inode, the stat (permissions, modification
+        time, etc.) of the source file is copied to the new fake file.
+
+        This helper method can be used to set up tests more easily.
+
+        Args:
+          real_file_path: Path to the source file in the real file system.
+          fake_file_path: path to the destination file in the fake file system.
+          create_missing_dirs: if True, auto create missing directories.
+
+        Returns:
+          the newly created FakeFile object.
+
+        Raises:
+          IOError: if the file already exists.
+          IOError: if the containing directory is required but missing.
+        """
+        real_stat = os.stat(real_file_path)
+        with open(real_file_path, 'rb') as real_file:
+            real_contents = real_file.read()
+        file_object = self.CreateFile(fake_file_path, st_mode=real_stat.st_mode,
+                                    contents=real_contents,
+                                    create_missing_dirs=create_missing_dirs)
+        file_object.st_ctime = real_stat.st_ctime
+        file_object.st_atime = real_stat.st_atime
+        file_object.st_mtime = real_stat.st_mtime
+        file_object.st_nlink = real_stat.st_nlink
+        file_object.st_dev = real_stat.st_dev
+        file_object.st_gid = real_stat.st_gid
+        file_object.st_uid = real_stat.st_uid
         return file_object
 
     # pylint: disable=unused-argument

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -1,5 +1,6 @@
 # Copyright 2014 Altera Corporation. All Rights Reserved.
-# Copyright 2015 John McGehee
+# Copyright 2015-2017 John McGehee
+# Author: John McGehee
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +40,7 @@ retrofitted to use `pyfakefs` by simply changing their base class from
 `:py:class`pyfakefs.fake_filesystem_unittest.TestCase`.
 """
 
+import os
 import sys
 import doctest
 import inspect
@@ -60,6 +62,11 @@ if sys.version_info < (3,):
     import __builtin__ as builtins  # pylint: disable=import-error
 else:
     import builtins
+
+REAL_OPEN = builtins.open
+"""The real (not faked) `open` builtin."""
+REAL_OS = os
+"""The real (not faked) `os` module."""
 
 
 def load_doctests(loader, tests, ignore, module):  # pylint: disable=unused-argument
@@ -112,6 +119,43 @@ class TestCase(unittest.TestCase):
     @property
     def patches(self):
         return self._stubber.patches
+
+    def CopyRealFile(self, real_file_path, fake_file_path=None,
+                     create_missing_dirs=True):
+        """Copy the file `real_file_path` from the real file system to the fake
+        file system file `fake_file_path`.
+
+        This is a helper method you can use to set up your test more easily.
+
+        The permissions, gid, uid, ctime, mtime and atime of the real file are
+        copied to the fake file.  nlink, dev, and inode are not copied because
+        their values depend on the fake file system, not the real file system
+        from which the file was copied.
+
+        Args:
+          real_file_path: Path to the source file in the real file system.
+          fake_file_path: path to the destination file in the fake file system.
+          create_missing_dirs: if True, auto create missing directories.
+
+        Returns:
+          The newly created FakeFile object.
+
+        Raises:
+          IOError: if the file already exists.
+          IOError: if the containing directory is required and missing.
+        """
+        real_stat = REAL_OS.stat(real_file_path)
+        with REAL_OPEN(real_file_path, 'rb') as real_file:
+            real_contents = real_file.read()
+        fake_file = self.fs.CreateFile(fake_file_path, st_mode=real_stat.st_mode,
+                                    contents=real_contents,
+                                    create_missing_dirs=create_missing_dirs)
+        fake_file.st_ctime = real_stat.st_ctime
+        fake_file.st_atime = real_stat.st_atime
+        fake_file.st_mtime = real_stat.st_mtime
+        fake_file.st_gid = real_stat.st_gid
+        fake_file.st_uid = real_stat.st_uid
+        return fake_file
 
     def setUpPyfakefs(self):
         """Bind the file-related modules to the :py:class:`pyfakefs` fake file

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -120,29 +120,28 @@ class TestCase(unittest.TestCase):
         return self._stubber.patches
 
     if sys.version_info >= (2, 7):
-        def CopyRealFile(self, real_file_path, fake_file_path=None,
+        def copyRealFile(self, real_file_path, fake_file_path=None,
                          create_missing_dirs=True):
             """Copy the file `real_file_path` from the real file system to the fake
             file system file `fake_file_path`.  The permissions, gid, uid, ctime,
             mtime and atime of the real file are copied to the fake file.
-            
+
            This is a helper method you can use to set up your test more easily.
-           
+
            This method is available in Python 2.7 and above.
-    
+
             Args:
               real_file_path: Path to the source file in the real file system.
               fake_file_path: path to the destination file in the fake file system.
               create_missing_dirs: if True, auto create missing directories.
-    
+
             Returns:
               the newly created FakeFile object.
-    
+
             Raises:
               IOError: if the file already exists.
               IOError: if the containing directory is required and missing.
             """
-            assert 
             real_stat = REAL_OS.stat(real_file_path)
             with REAL_OPEN(real_file_path, 'rb') as real_file:
                 real_contents = real_file.read()

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -1,6 +1,5 @@
 # Copyright 2014 Altera Corporation. All Rights Reserved.
-# Copyright 2015-2017 John McGehee
-# Author: John McGehee
+# Copyright 2015 John McGehee
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -120,42 +119,42 @@ class TestCase(unittest.TestCase):
     def patches(self):
         return self._stubber.patches
 
-    def CopyRealFile(self, real_file_path, fake_file_path=None,
-                     create_missing_dirs=True):
-        """Copy the file `real_file_path` from the real file system to the fake
-        file system file `fake_file_path`.
-
-        This is a helper method you can use to set up your test more easily.
-
-        The permissions, gid, uid, ctime, mtime and atime of the real file are
-        copied to the fake file.  nlink, dev, and inode are not copied because
-        their values depend on the fake file system, not the real file system
-        from which the file was copied.
-
-        Args:
-          real_file_path: Path to the source file in the real file system.
-          fake_file_path: path to the destination file in the fake file system.
-          create_missing_dirs: if True, auto create missing directories.
-
-        Returns:
-          The newly created FakeFile object.
-
-        Raises:
-          IOError: if the file already exists.
-          IOError: if the containing directory is required and missing.
-        """
-        real_stat = REAL_OS.stat(real_file_path)
-        with REAL_OPEN(real_file_path, 'rb') as real_file:
-            real_contents = real_file.read()
-        fake_file = self.fs.CreateFile(fake_file_path, st_mode=real_stat.st_mode,
-                                    contents=real_contents,
-                                    create_missing_dirs=create_missing_dirs)
-        fake_file.st_ctime = real_stat.st_ctime
-        fake_file.st_atime = real_stat.st_atime
-        fake_file.st_mtime = real_stat.st_mtime
-        fake_file.st_gid = real_stat.st_gid
-        fake_file.st_uid = real_stat.st_uid
-        return fake_file
+    if sys.version_info >= (2, 7):
+        def CopyRealFile(self, real_file_path, fake_file_path=None,
+                         create_missing_dirs=True):
+            """Copy the file `real_file_path` from the real file system to the fake
+            file system file `fake_file_path`.  The permissions, gid, uid, ctime,
+            mtime and atime of the real file are copied to the fake file.
+            
+           This is a helper method you can use to set up your test more easily.
+           
+           This method is available in Python 2.7 and above.
+    
+            Args:
+              real_file_path: Path to the source file in the real file system.
+              fake_file_path: path to the destination file in the fake file system.
+              create_missing_dirs: if True, auto create missing directories.
+    
+            Returns:
+              the newly created FakeFile object.
+    
+            Raises:
+              IOError: if the file already exists.
+              IOError: if the containing directory is required and missing.
+            """
+            assert 
+            real_stat = REAL_OS.stat(real_file_path)
+            with REAL_OPEN(real_file_path, 'rb') as real_file:
+                real_contents = real_file.read()
+            fake_file = self.fs.CreateFile(fake_file_path, st_mode=real_stat.st_mode,
+                                        contents=real_contents,
+                                        create_missing_dirs=create_missing_dirs)
+            fake_file.st_ctime = real_stat.st_ctime
+            fake_file.st_atime = real_stat.st_atime
+            fake_file.st_mtime = real_stat.st_mtime
+            fake_file.st_gid = real_stat.st_gid
+            fake_file.st_uid = real_stat.st_uid
+            return fake_file
 
     def setUpPyfakefs(self):
         """Bind the file-related modules to the :py:class:`pyfakefs` fake file


### PR DESCRIPTION
This copies a file from the real file system to
the fake file system, making it easy to use
files from the real file system in your tests.

@mrbean-bremen, please review.