### PR TITLE
Minor changes to copyRealFile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,12 @@ The release versions are PyPi releases.
 
 ## Version 3.1 (as yet unreleased)
 
- * Added helper method `FakeFile.CopyRealFile()` to copy a file from \
-   the real file system to the fake file system.  This makes it easy to use \
+#### New Features
+ * Added helper method `TestCase.copyRealFile()` to copy a file from
+   the real file system to the fake file system. This makes it easy to use
    files from the real file system in your tests.
+ * A pytest plugin is now installed with pyfakefs that exports `fs`
+   as a pytest fixture.
 
 ## Version 3.0
 

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -171,13 +171,11 @@ class TestPatchPathUnittestPassing(TestPyfakefsUnittestBase):
 class TestCopyRealFile(TestPyfakefsUnittestBase):
     """Tests the `fake_filesystem_unittest.TestCase.copyRealFile()` method."""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.real_stat = os.stat(__file__)
-        with open(__file__) as f:
-            cls.real_string_contents = f.read()
-        with open(__file__, 'rb') as f:
-            cls.real_byte_contents = f.read()
+    real_stat = os.stat(__file__)
+    with open(__file__) as f:
+        real_string_contents = f.read()
+    with open(__file__, 'rb') as f:
+        real_byte_contents = f.read()
 
     def testCopyRealFile(self):
         '''Copy a real file to the fake file system'''
@@ -190,7 +188,8 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
                         'Verify real file string contents')
         self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
                         'Verify real file byte contents')
-        self.assertEqual(fake_file.contents, self.real_string_contents)
+
+        # note that real_string_contents may differ to fake_file.contents due to newline conversions in open()
         self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
 
         self.assertEqual(fake_file.st_mode, self.real_stat.st_mode)

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -49,6 +49,7 @@ import mox3.stubout
 from pyfakefs import fake_filesystem
 from pyfakefs import fake_filesystem_shutil
 from pyfakefs import fake_tempfile
+
 if sys.version_info >= (3, 4):
     from pyfakefs import fake_pathlib
 
@@ -119,41 +120,40 @@ class TestCase(unittest.TestCase):
     def patches(self):
         return self._stubber.patches
 
-    if sys.version_info >= (2, 7):
-        def copyRealFile(self, real_file_path, fake_file_path=None,
-                         create_missing_dirs=True):
-            """Copy the file `real_file_path` from the real file system to the fake
-            file system file `fake_file_path`.  The permissions, gid, uid, ctime,
-            mtime and atime of the real file are copied to the fake file.
+    def copyRealFile(self, real_file_path, fake_file_path=None,
+                     create_missing_dirs=True):
+        """Copy the file `real_file_path` from the real file system to the fake
+        file system file `fake_file_path`.  The permissions, gid, uid, ctime,
+        mtime and atime of the real file are copied to the fake file.
 
-           This is a helper method you can use to set up your test more easily.
+       This is a helper method you can use to set up your test more easily.
 
-           This method is available in Python 2.7 and above.
+       This method is available in Python 2.7 and above.
 
-            Args:
-              real_file_path: Path to the source file in the real file system.
-              fake_file_path: path to the destination file in the fake file system.
-              create_missing_dirs: if True, auto create missing directories.
+        Args:
+          real_file_path: Path to the source file in the real file system.
+          fake_file_path: path to the destination file in the fake file system.
+          create_missing_dirs: if True, auto create missing directories.
 
-            Returns:
-              the newly created FakeFile object.
+        Returns:
+          the newly created FakeFile object.
 
-            Raises:
-              IOError: if the file already exists.
-              IOError: if the containing directory is required and missing.
-            """
-            real_stat = REAL_OS.stat(real_file_path)
-            with REAL_OPEN(real_file_path, 'rb') as real_file:
-                real_contents = real_file.read()
-            fake_file = self.fs.CreateFile(fake_file_path, st_mode=real_stat.st_mode,
-                                        contents=real_contents,
-                                        create_missing_dirs=create_missing_dirs)
-            fake_file.st_ctime = real_stat.st_ctime
-            fake_file.st_atime = real_stat.st_atime
-            fake_file.st_mtime = real_stat.st_mtime
-            fake_file.st_gid = real_stat.st_gid
-            fake_file.st_uid = real_stat.st_uid
-            return fake_file
+        Raises:
+          IOError: if the file already exists.
+          IOError: if the containing directory is required and missing.
+        """
+        real_stat = REAL_OS.stat(real_file_path)
+        with REAL_OPEN(real_file_path, 'rb') as real_file:
+            real_contents = real_file.read()
+        fake_file = self.fs.CreateFile(fake_file_path, st_mode=real_stat.st_mode,
+                                       contents=real_contents,
+                                       create_missing_dirs=create_missing_dirs)
+        fake_file.st_ctime = real_stat.st_ctime
+        fake_file.st_atime = real_stat.st_atime
+        fake_file.st_mtime = real_stat.st_mtime
+        fake_file.st_gid = real_stat.st_gid
+        fake_file.st_uid = real_stat.st_uid
+        return fake_file
 
     def setUpPyfakefs(self):
         """Bind the file-related modules to the :py:class:`pyfakefs` fake file
@@ -262,7 +262,7 @@ class Patcher(object):
         for name, module in set(sys.modules.items()):
             if (module in self.SKIPMODULES or
                     (not inspect.ismodule(module)) or
-                    name.split('.')[0] in self._skipNames):
+                        name.split('.')[0] in self._skipNames):
                 continue
             if 'os' in module.__dict__:
                 self._os_modules.add(module)


### PR DESCRIPTION
- do not test the whole string contents as this will not work with other line endings (e.g. on Windows)
- moved setUpClass() code into class as setUpClass() is not available under Python 2.6