### PR TITLE
Correct test to properly test copyRealFile() atime on MacOS

### DIFF
--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -170,12 +170,14 @@ class TestPatchPathUnittestPassing(TestPyfakefsUnittestBase):
 @unittest.skipIf(sys.version_info < (2, 7), "No byte strings in Python 2.6")
 class TestCopyRealFile(TestPyfakefsUnittestBase):
     """Tests the `fake_filesystem_unittest.TestCase.copyRealFile()` method."""
-
-    real_stat = os.stat(__file__)
     with open(__file__) as f:
         real_string_contents = f.read()
     with open(__file__, 'rb') as f:
         real_byte_contents = f.read()
+    # It is essential to do os.stat() after opening the real file, not before.
+    # This is because opening the file on MacOS and BSD updates access time
+    # st_atime.  Windows offers the option to enable this behavior as well.
+    real_stat = os.stat(__file__)
 
     def testCopyRealFile(self):
         '''Copy a real file to the fake file system'''

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -141,6 +141,18 @@ class TestCase(unittest.TestCase):
         Raises:
           IOError: if the file already exists.
           IOError: if the containing directory is required and missing.
+
+        .. note:: The fake file's atime is the access time of the real file \
+                  before it accessed by `copyRealFile()`.  Then, the real file \
+                  is opened in order to copy its contents, whereupon \
+                  **MacOS and BSD update the real file's atime** to the time \
+                  at which your test used `copyRealFile()`. \
+                  \
+                  Thus on these platforms atime is subject to Heisenberg's \
+                  uncertainty principle--by merely accessing the real file, \
+                  your test changes the real file's atime.  Further, Windows \
+                  offers the option to enable atime, and older versions of \
+                  Linux may also modify atime.
         """
         real_stat = REAL_OS.stat(real_file_path)
         with REAL_OPEN(real_file_path, 'rb') as real_file:


### PR DESCRIPTION
Updated the documentation to clarify this issue.  @mrbean-bremen, please review using your knowledge of file systems.

This problem manifests on MacOS because it updates atime, whereas Linux and Windows do not.

Because this is not a functional change, I did not add this issue to the release notes.