### PR TITLE
Derive SetLargeFileSizeTest directly from TestCase

### DIFF
--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -160,7 +160,10 @@ class FakeDirectoryUnitTest(TestCase):
         self.assertEqual(['2', '4', '1', '3'], fake_dir.ordered_dirs)
 
 
-class SetLargeFileSizeTest(FakeDirectoryUnitTest):
+class SetLargeFileSizeTest(TestCase):
+    def setUp(self):
+        self.fake_file = fake_filesystem.FakeFile('foobar')
+
     def testShouldThrowIfSizeIsNotInteger(self):
         self.assertRaisesIOError(errno.ENOSPC, self.fake_file.SetLargeFileSize, 0.1)
 


### PR DESCRIPTION
SetLargeFileSizeTest should derive directly from unittest.TestCase instead
of FakeDirectoryUnitTest, to avoid running tests in FakeDirectoryUnitTest
twice.