### PR TITLE
copyRealFile fake_file_path defaults to real_file_path

### DIFF
--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -207,6 +207,29 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
             self.copyRealFile(real_file_path, fake_file_path,
                               create_missing_dirs=False)
 
+    def testCopyRealFileNoDestination(self):
+        real_file_path = __file__
+        fake_file = self.copyRealFile(real_file_path)
+
+        self.assertTrue('class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_string_contents,
+                        'Verify real file string contents')
+        self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
+                        'Verify real file byte contents')
+
+        # note that real_string_contents may differ to fake_file.contents due to newline conversions in open()
+        self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
+
+        self.assertEqual(fake_file.st_mode, self.real_stat.st_mode)
+        self.assertEqual(fake_file.st_size, self.real_stat.st_size)
+        self.assertEqual(fake_file.st_ctime, self.real_stat.st_ctime)
+        self.assertEqual(fake_file.st_atime, self.real_stat.st_atime)
+        self.assertEqual(fake_file.st_mtime, self.real_stat.st_mtime)
+        self.assertEqual(fake_file.st_uid, self.real_stat.st_uid)
+        self.assertEqual(fake_file.st_gid, self.real_stat.st_gid)
+
+        with self.assertRaises(IOError):
+            self.copyRealFile(real_file_path, create_missing_dirs=False)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -209,26 +209,9 @@ class TestCopyRealFile(TestPyfakefsUnittestBase):
 
     def testCopyRealFileNoDestination(self):
         real_file_path = __file__
-        fake_file = self.copyRealFile(real_file_path)
-
-        self.assertTrue('class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_string_contents,
-                        'Verify real file string contents')
-        self.assertTrue(b'class TestCopyRealFile(TestPyfakefsUnittestBase)' in self.real_byte_contents,
-                        'Verify real file byte contents')
-
-        # note that real_string_contents may differ to fake_file.contents due to newline conversions in open()
-        self.assertEqual(fake_file.byte_contents, self.real_byte_contents)
-
-        self.assertEqual(fake_file.st_mode, self.real_stat.st_mode)
-        self.assertEqual(fake_file.st_size, self.real_stat.st_size)
-        self.assertEqual(fake_file.st_ctime, self.real_stat.st_ctime)
-        self.assertEqual(fake_file.st_atime, self.real_stat.st_atime)
-        self.assertEqual(fake_file.st_mtime, self.real_stat.st_mtime)
-        self.assertEqual(fake_file.st_uid, self.real_stat.st_uid)
-        self.assertEqual(fake_file.st_gid, self.real_stat.st_gid)
-
-        with self.assertRaises(IOError):
-            self.copyRealFile(real_file_path, create_missing_dirs=False)
+        self.assertFalse(self.fs.Exists(real_file_path))
+        self.copyRealFile(real_file_path)
+        self.assertTrue(self.fs.Exists(real_file_path))
 
 
 if __name__ == "__main__":

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -130,7 +130,7 @@ class TestCase(unittest.TestCase):
 
         Args:
           real_file_path: Path to the source file in the real file system.
-          fake_file_path: path to the destination file in the fake file system.
+          fake_file_path: path to the destination file in the fake file system.  Defaults to real_file_path.
           create_missing_dirs: if True, auto create missing directories.
 
         Returns:
@@ -152,6 +152,8 @@ class TestCase(unittest.TestCase):
                   offers the option to enable atime, and older versions of \
                   Linux may also modify atime.
         """
+        if not fake_file_path:
+            fake_file_path = real_file_path
         real_stat = REAL_OS.stat(real_file_path)
         with REAL_OPEN(real_file_path, 'rb') as real_file:
             real_contents = real_file.read()

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -130,7 +130,8 @@ class TestCase(unittest.TestCase):
 
         Args:
           real_file_path: Path to the source file in the real file system.
-          fake_file_path: path to the destination file in the fake file system.  Defaults to real_file_path.
+          fake_file_path: path to the destination file in the fake file system.
+            Defaults to real_file_path.
           create_missing_dirs: if True, auto create missing directories.
 
         Returns:
@@ -152,7 +153,7 @@ class TestCase(unittest.TestCase):
                   offers the option to enable atime, and older versions of \
                   Linux may also modify atime.
         """
-        if not fake_file_path:
+        if fake_file_path is None:
             fake_file_path = real_file_path
         real_stat = REAL_OS.stat(real_file_path)
         with REAL_OPEN(real_file_path, 'rb') as real_file:


### PR DESCRIPTION
Changed TestCase.copyRealFile to default the value of fake_file_path to the same value as real_file_path, when fake_file_path is not provided/None.