### PR TITLE
Fixed handling of invalid parent paths in CreateDirectory()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ The release versions are PyPi releases.
 #### Infrastructure
 
 #### Fixes
+  * Incorrect error handling during directory creation ([#209](../../issues/209)) 
   * Creating files in read-only directory was possible ([#203](../../issues/203))
 
 ## [Version 3.2](https://pypi.python.org/pypi/pyfakefs/3.2)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,py36,py37,pypy
+envlist=py26,py27,py33,py34,py35,py36
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
- fixed handling of symlinks in MakeDirectories()
- fixed exception thrown on too many symlinks
- see #209