### PR TITLE
Test case mixin

### DIFF
--- a/tests/fake_filesystem_unittest_test.py
+++ b/tests/fake_filesystem_unittest_test.py
@@ -324,5 +324,19 @@ class TestCopyOrAddRealFile(TestPyfakefsUnittestBase):
         self.assertTrue(self.fs.exists(os.path.join(real_dir_path, 'fake_filesystem.py')))
 
 
+class TestPyfakefsTestCase(unittest.TestCase):
+    def setUp(self):
+        class TestTestCase(fake_filesystem_unittest.TestCase):
+            def runTest(self):
+                pass
+
+        self.test_case = TestTestCase('runTest')
+
+    def test_test_case_type(self):
+        self.assertIsInstance(self.test_case, unittest.TestCase)
+
+        self.assertIsInstance(self.test_case, fake_filesystem_unittest.TestCaseMixin)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/fake_os_test.py
+++ b/tests/fake_os_test.py
@@ -3187,6 +3187,10 @@ class FakeOsModuleTimeTest(FakeOsModuleTestBase):
 class FakeOsModuleLowLevelFileOpTest(FakeOsModuleTestBase):
     """Test low level functions `os.open()`, `os.read()` and `os.write()`."""
 
+    def setUp(self):
+        os.umask(0o022)
+        super(FakeOsModuleLowLevelFileOpTest, self).setUp()
+
     def test_open_read_only(self):
         file_path = self.make_path('file1')
         self.create_file(file_path, contents=b'contents')


### PR DESCRIPTION
This PR splits TestCase into TestCaseMixin and TestCase. The TestCaseMixin class can be used with other than unittest.TestCase TestCase classes (for example, django.test.TestCase or asynctest.TestCase)