### PR TITLE
Fix undefined names in Python3

### DIFF
--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -121,6 +121,11 @@ PERM_DEF = 0o777  # Default permission bits.
 PERM_DEF_FILE = 0o666  # Default permission bits (regular file)
 PERM_ALL = 0o7777  # All permission bits.
 
+try:
+    text_type = unicode  # Python 2
+except NameError:
+    text_type = str      # Python 3
+
 _OpenModes = namedtuple(
     'open_modes',
     'must_exist can_read can_write truncate append must_not_exist'
@@ -822,7 +827,7 @@ class FakeFilesystem(object):
         with the error string issued in the real system.
         Note: this is not true under Windows if winerror is given - in this case
         a localized message specific to winerror will be shown in the real file system.
-        
+
         Args:
             errno: A numeric error code from the C variable errno.
             filename: The name of the affected file, if any.
@@ -838,7 +843,7 @@ class FakeFilesystem(object):
     def raise_io_error(self, errno, filename=None):
         """Raises IOError.
         The error message is constructed from the given error code and shall start
-        with the error in the real system. 
+        with the error in the real system.
 
         Args:
             errno: A numeric error code from the C variable errno.
@@ -855,8 +860,8 @@ class FakeFilesystem(object):
             return string
         if IS_PY2:
             # pylint: disable=undefined-variable
-            if isinstance(matched, unicode):
-                return unicode(string)
+            if isinstance(matched, text_type):
+                return text_type(string)
         else:
             if isinstance(matched, bytes) and isinstance(string, str):
                 return string.encode(locale.getpreferredencoding(False))
@@ -2877,7 +2882,7 @@ class FakePathModule(object):
         def getcwd():
             """Return the current working directory."""
             # pylint: disable=undefined-variable
-            if IS_PY2 and isinstance(path, unicode):
+            if IS_PY2 and isinstance(path, text_type):
                 return self.os.getcwdu()
             elif not IS_PY2 and isinstance(path, bytes):
                 return self.os.getcwdb()
@@ -3386,7 +3391,7 @@ class FakeOsModule(object):
     if IS_PY2:
         def getcwdu(self):
             """Return current working directory as unicode. Python 2 only."""
-            return unicode(self.filesystem.cwd)  # pylint: disable=undefined-variable
+            return text_type(self.filesystem.cwd)  # pylint: disable=undefined-variable
 
     else:
         def getcwdb(self):

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -17,14 +17,15 @@ import sys
 from copy import copy
 from stat import S_IFLNK
 
-IS_PY2 = sys.version_info[0] == 2
+IS_PY2 = sys.version_info[0] < 3
 
 
 def is_int_type(val):
     """Return True if `val` is of integer type."""
-    # pylint: disable=undefined-variable
-    int_types = (int, long) if IS_PY2 else int
-    return isinstance(val, int_types)
+    try:               # Python 2
+        return isinstance(val, (int, long))
+    except NameError:  # Python 3
+        return isinstance(val, int)
 
 
 def is_byte_string(val):
@@ -38,9 +39,10 @@ def is_byte_string(val):
 def is_unicode_string(val):
     """Return True if `val` is a unicode string, False for a bytes-like
     object."""
-    if not IS_PY2:
+    try:               # Python 2
+        return isinstance(val, unicode)
+    except NameError:  # Python 3
         return hasattr(val, 'encode')
-    return isinstance(val, unicode)
 
 
 class FakeStatResult(object):
@@ -48,8 +50,10 @@ class FakeStatResult(object):
     This is needed as `os.stat_result` has no possibility to set
     nanosecond times directly.
     """
-    # pylint: disable=undefined-variable
-    long_type = long if sys.version_info[0] == 2 else int
+    try:
+        long_type = long  # Python 2
+    except NameError:
+        long_type = int   # Python 3
     _stat_float_times = sys.version_info >= (2, 5)
 
     def __init__(self, is_windows, initial_time=None):

--- a/tests/fake_filesystem_unittest_test.py
+++ b/tests/fake_filesystem_unittest_test.py
@@ -57,10 +57,10 @@ class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
     def test_file(self):
         """Fake `file()` function is bound"""
         self.assertFalse(os.path.exists('/fake_file.txt'))
-        with file('/fake_file.txt', 'w') as f:
+        with file('/fake_file.txt', 'w') as f:  # noqa: F821 is only run on Py2
             f.write("This test file was created using the file() function.\n")
         self.assertTrue(self.fs.exists('/fake_file.txt'))
-        with file('/fake_file.txt') as f:
+        with file('/fake_file.txt') as f:       # noqa: F821 is only run on Py2
             content = f.read()
         self.assertEqual(content,
                          'This test file was created using the file() function.\n')


### PR DESCRIPTION
The _try: except NameError:__ approach follows the Python porting best practice [Use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) and keeps the linters at bay.

The alternative approach uses the very popular [six](http://six.readthedocs.io) module instead.