### PR TITLE
Remove unnecessary shebang line

### DIFF
--- a/pyfakefs/fake_filesystem_shutil.py
+++ b/pyfakefs/fake_filesystem_shutil.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright 2009 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This removes an unnecessary shebang line from `fake_filesystem_shutil.py`, as
this file is a Python module and isn't invoked via CLI.