### PR TITLE
Fix using setUpPyfakefs when using TestCaseMixin

### DIFF
--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -161,7 +161,7 @@ class TestCaseMixin(object):
     """
 
     additional_skip_names = None
-    patch_patch = True
+    patch_path = True
     modules_to_reload = None
     use_dynamic_patch = True
     modules_to_patch = None

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -366,5 +366,13 @@ class TestTempFileReload(unittest.TestCase):
         self.assertEqual(v.value, 0)
 
 
+class TestPyfakefsTestCaseMixin(unittest.TestCase, fake_filesystem_unittest.TestCaseMixin):
+    def test_set_up_pyfakefs(self):
+        self.setUpPyfakefs()
+
+        self.assertTrue(hasattr(self, 'fs'))
+        self.assertIsInstance(self.fs, fake_filesystem.FakeFilesystem)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
My previous pull request had typo in it due to having the patch_path set in the code that was using the mixin and not adding unit test for the setUpPyfakefs method.