### PR TITLE
Fixed regression for isDir() with trailing separator under MacOS

### DIFF
--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -2657,7 +2657,7 @@ class FakeFilesystem(object):
             obj = self.resolve(path, follow_symlinks)
             if obj:
                 self.raise_for_filepath_ending_with_separator(
-                    path, obj, macos_handling=True)
+                    path, obj, macos_handling=not follow_symlinks)
                 return S_IFMT(obj.st_mode) == st_flag
         except (IOError, OSError):
             return False

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -1212,6 +1212,10 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.check_macos_only()
         self.check_append_mode_tell_after_truncate(7)
 
+    def test_dir_with_trailing_sep_is_dir(self):
+        # regression test for #387
+        self.assertTrue(self, self.os.path.isdir(self.base_path + self.os.sep))
+
     def test_rename_dir(self):
         """Test a rename of a directory."""
         directory = self.make_path('xyzzy')


### PR DESCRIPTION
- fixes #387 