### PR TITLE
binary readline (Py3) fixed

### DIFF
--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -302,14 +302,19 @@ class FileBufferIO(object):
     def readline(self, size=-1):
         seek_pos = self._bytestream.tell()
         byte_contents = self._bytestream.read(size)
-        read_contents = self.convert_newlines_after_reading(
-            self.decoded_string(byte_contents))
+        if self.binary:
+            read_contents = byte_contents
+            LF = b'\n'
+        else:
+            read_contents = self.convert_newlines_after_reading(
+                self.decoded_string(byte_contents))
+            LF = '\n'
         end_pos = 0
 
         if self._newline is None:
             end_pos = self._linelen_for_universal_newlines(byte_contents)
             if end_pos > 0:
-                length = read_contents.find('\n') + 1
+                length = read_contents.find(LF) + 1
         elif self._newline == '':
             end_pos = self._linelen_for_universal_newlines(byte_contents)
             if end_pos > 0:
@@ -337,6 +342,8 @@ class FileBufferIO(object):
                 else read_contents[:length])
 
     def _linelen_for_universal_newlines(self, byte_contents):
+        if self.binary:
+            return byte_contents.find(b'\n') + 1
         pos_lf = byte_contents.find(b'\n')
         pos_cr = byte_contents.find(b'\r')
         if pos_lf == -1 and pos_cr == -1:

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -1268,6 +1268,25 @@ class FakeFileOpenLineEndingTest(FakeFileOpenTestBase):
         with self.open(file_path, mode='rb') as f:
             self.assertEqual(b'1\r\r2\r3\r4', f.read())
 
+    def test_binary_readline(self):
+        file_path = self.make_path('some_file')
+        file_contents = b'\x80\n\x80\r\x80\r\n\x80'
+
+        def chunk_line():
+            px = ix = 0
+            while px < len(file_contents):
+                ix = file_contents.find(b'\n', px)
+                if ix == -1:
+                    yield file_contents[px:]
+                    return
+                yield file_contents[px:ix+1]
+                px = ix + 1
+
+        chunked_contents = list(chunk_line())
+        self.create_file(file_path, contents=file_contents)
+        with self.open(file_path, mode='rb') as f:
+            self.assertEqual(chunked_contents, list(f))
+
 
 class RealFileOpenLineEndingTest(FakeFileOpenLineEndingTest):
     def use_real_fs(self):


### PR DESCRIPTION
Using `readline()` on a binary file may throw an exception in the Python3 environment; and some standard Python libraries do that, most notably `pickle.load()`. The problem is that binary contents should not be decoded and at the same time all EOL searches should use `bytes` form of the EOL sequence.