### PR TITLE
Make sure that the linecache module is not using the fake file system

### DIFF
--- a/.travis/run_pytest.sh
+++ b/.travis/run_pytest.sh
@@ -5,3 +5,5 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 fi
 
 python -m pytest pyfakefs/tests/pytest_plugin_test.py
+python -m pytest pyfakefs/tests/pytest_plugin_failing_test.py > ./testresult.txt
+python -m pytest pyfakefs/tests/pytest_check_failed_plugin_test.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,5 @@ build: off
 test_script:
   - "%PYTHON%\\python.exe -m pyfakefs.tests.all_tests"
   - "%PYTHON%\\python.exe -m pytest pyfakefs\\tests\\pytest_plugin_test.py"
-
+  - "%PYTHON%\\python.exe -m pytest pyfakefs\\tests\\pytest_plugin_failing_test.py > testresult.txt | echo."
+  - "%PYTHON%\\python.exe -m pytest pyfakefs\\tests\\pytest_check_failed_plugin_test.py"

--- a/pyfakefs/pytest_plugin.py
+++ b/pyfakefs/pytest_plugin.py
@@ -8,15 +8,28 @@ def my_fakefs_test(fs):
     fs.create_file('/var/data/xx1.txt')
     assert os.path.exists('/var/data/xx1.txt')
 """
+
 import linecache
 
 import py
 import pytest
+
 from pyfakefs.fake_filesystem_unittest import Patcher
 
-Patcher.SKIPMODULES.add(py)  # Ignore pytest components when faking filesystem
-Patcher.SKIPMODULES.add(linecache)  # Seems to be used by pytest internally
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
 
+Patcher.SKIPMODULES.add(py)  # Ignore pytest components when faking filesystem
+
+# The "linecache" module is used to read the test file in case of test failure
+# to get traceback information before test tear down.
+# In order to make sure that reading the test file is not faked,
+# we both skip faking the module, and add the build-in open() function
+# as a local function in the module
+Patcher.SKIPMODULES.add(linecache)
+linecache.open = builtins.open
 
 @pytest.fixture
 def fs(request):

--- a/pyfakefs/tests/pytest_check_failed_plugin_test.py
+++ b/pyfakefs/tests/pytest_check_failed_plugin_test.py
@@ -1,0 +1,19 @@
+"""Tests that a failed pytest properly displays the call stack.
+Uses the output from running pytest with pytest_plugin_failing_test.py.
+Regression test for #381.
+"""
+import pytest
+import sys
+
+
+@pytest.mark.skipif(sys.version_info[0] == 3 and sys.version_info[1] == 3,
+                    reason='linecache uses fake fs in Python 3.3')
+def test_failed_testresult_stacktrace():
+    with open('testresult.txt') as f:
+        contents = f.read()
+    # before the fix, a triple question mark has been displayed
+    # instead of the stacktrace
+    assert contents
+    print('contents', contents)
+    assert not '???' in contents
+    assert 'def test_fs(fs):' in contents

--- a/pyfakefs/tests/pytest_plugin_failing_test.py
+++ b/pyfakefs/tests/pytest_plugin_failing_test.py
@@ -1,0 +1,5 @@
+""" Failing test to test stacktrace output - see
+``pytest_check_failed_plugin_test.py``."""
+
+def test_fs(fs):
+    assert False


### PR DESCRIPTION
- does not work for Python 3.3 (which should not be used anymore anyway)
- see #381