### PR TITLE
Removed patch_path argument from UnitTest and Patcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ The release versions are PyPi releases.
 ## Version 3.5 (as yet unreleased)
 
 #### New Features
+  * parameter `patch_path` has been removed from `UnitTest` and `Patcher`, 
+    the correct patching of `path` imports is now done automatically
   * added pathlib2 support ([#408](../../issues/408)) ([#422](../../issues/422))
   * added some support for extended filesystem attributes under Linux 
   ([#423](../../issues/423)) 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -122,8 +122,7 @@ The following imports of ``os`` and ``pathlib.Path`` will not be patched by
   from pathlib import Path
 
 .. note:: There is one exception to that: importing ``os.path`` like
-  ``from os import path`` will work, because it is handled by ``pyfakefs``
-  (see also ``patch_path`` below).
+  ``from os import path`` will work, because it is handled by ``pyfakefs``.
 
 If adding the module containing these imports to ``modules_to_reload``, they
 will be correctly patched.
@@ -169,13 +168,6 @@ Here is an example of how to implement ``MyFakePath``:
 
         def __getattr__(self, name):
             return getattr(self.fake_pathlib.Path, name)
-
-patch_path
-~~~~~~~~~~
-This is True by default, meaning that modules named ``path`` are patched as
-``os.path``. If this clashes with another module of the same name, it can be
-switched off (and imports like ``from os import path`` will not be patched).
-
 
 additional_skip_names
 ~~~~~~~~~~~~~~~~~~~~~

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -175,30 +175,14 @@ class TestAttributesWithFakeModuleNames(TestPyfakefsUnittestBase):
 import math as path  # noqa: E402 wanted import not at top
 
 
-class TestPatchPathUnittestFailing(TestPyfakefsUnittestBase):
-    """Tests the default behavior regarding the argument patch_path:
-       An own path module (in this case an alias to math) cannot be imported,
-       because it is faked by FakePathModule
-    """
-
-    def __init__(self, methodName='runTest'):
-        super(TestPatchPathUnittestFailing, self).__init__(methodName,
-                                                           patch_path=True)
-
-    @unittest.expectedFailure
-    def test_own_path_module(self):
-        self.assertEqual(2, path.floor(2.5))
-
-
-class TestPatchPathUnittestPassing(TestPyfakefsUnittestBase):
-    """Tests the behavior with patch_path set to False:
+class TestPathNotPatchedIfNotOsPath(TestPyfakefsUnittestBase):
+    """Tests that `path` is not patched if it is not `os.path`.
        An own path module (in this case an alias to math) can be imported
        and used.
     """
 
     def __init__(self, methodName='runTest'):
-        super(TestPatchPathUnittestPassing, self).__init__(methodName,
-                                                           patch_path=False)
+        super(TestPathNotPatchedIfNotOsPath, self).__init__(methodName)
 
     def test_own_path_module(self):
         self.assertEqual(2, path.floor(2.5))


### PR DESCRIPTION
- path is only patched if it is os.path (detected by name)