### PR TITLE
Add side_effect option to fake files

### DIFF
--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -360,6 +360,7 @@ class FakeFile(object):
 
     def set_contents(self, contents, encoding=None):
         """Sets the file contents and size and increases the modification time.
+        Also executes the side_effects if available.
 
         Args:
           contents: (str, bytes, unicode) new content of file.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -221,7 +221,8 @@ class FakeFile(object):
             encoding: If contents is a unicode string, the encoding used
                 for serialization.
             errors: The error mode used for encoding/decoding errors.
-            side_effect: TODO
+            side_effect: function handle that is executed when file is written,
+                must accept the file object as an argument.
         """
         # to be backwards compatible regarding argument order, we raise on None
         if filesystem is None:
@@ -2278,7 +2279,8 @@ class FakeFilesystem(object):
             encoding: If `contents` is a unicode string, the encoding used
                 for serialization.
             errors: The error mode used for encoding/decoding errors.
-            side_effect: TODO
+            side_effect: function handle that is executed when file is written,
+                must accept the file object as an argument.
 
         Returns:
             The newly created FakeFile object.
@@ -2440,7 +2442,8 @@ class FakeFilesystem(object):
             read_from_real_fs: if True, the contents are read from the real
                 file system on demand.
             raw_io: `True` if called from low-level API (`os.open`)
-            side_effect: TODO
+            side_effect: function handle that is executed when file is written,
+                must accept the file object as an argument.
         """
         error_fct = self.raise_os_error if raw_io else self.raise_io_error
         file_path = self.make_string_path(file_path)


### PR DESCRIPTION
**Background:**
On linux, parts of the file system have other uses than being actual files. One example is "/sys/class/gpio".
To mock the expected behaviour in this example a "side effect" of writing to the files is needed:

1. When writing an int XX to "/sys/class/gpio/export" a new directory is created "/sys/class/gpio/gpioXX" with some files
2. when writing an int XX to "/sys/class/gpio/unexport" the directory "/sys/class/gpio/gpioXX" is removed.

This "side effect" needs to happen in the same way during testing as in real environment to not affect the SUT. For example, if the folder "/sys/class/gpio/gpioXX" is created in the setup of the test the SUT can see that gpioXX is already available and skip writing to "/sys/class/gpio/export".
Another solution could have been polling the files if export has been written to, however this problems as the polling must be much faster than the SUT the be able to cause the side_effect to simulate the real environment.

**Pull request:**
The proposed solution in this pull request is to add a side_effect argument to fake files which can contain a function handle that is invoked, with the file object as argument, after the file is written. This function then causes the "side effects" needed.
The default is to not have any "side effect", preserving legacy.
I also added 2 unittests for the new functionality.