### PR TITLE
Remove support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,29 @@ matrix:
     include:
         - python: 2.7
           env: PYTHON=py27
-        - python: 3.3
-          env: PYTHON=py33
         - python: 3.4
           env: PYTHON=py34
         - python: 3.5
           env: PYTHON=py35
         - python: 3.6
           env: PYTHON=py36
+        - python: 3.7
+          dist: xenial
+          sudo: true
+          env: PYTHON=py37
         - python: pypy2.7-5.8.0
           env: PYTHON=pypy2
         - python: pypy3.5-5.8.0
           env: PYTHON=pypy3
-        - python: 3.7-dev
-          env: PYTHON=py37
         - os: osx
           language: generic
           env: PYTHON=py27
         - os: osx
           language: generic
           env: PYTHON=py36
+        - os: osx
+          language: generic
+          env: PYTHON=py37
 
 install:
   - ./.travis/install.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -17,10 +17,6 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
             curl -O https://bootstrap.pypa.io/get-pip.py
             python get-pip.py --user
             ;;
-        py33)
-            pyenv install 3.3.5
-            pyenv global 3.3.5
-            ;;
         py34)
             pyenv install 3.4.4
             pyenv global 3.4.4
@@ -30,8 +26,12 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
             pyenv global 3.5.4
             ;;
         py36)
-            pyenv install 3.6.3
-            pyenv global 3.6.3
+            pyenv install 3.6.6
+            pyenv global 3.6.6
+            ;;
+        py37)
+            pyenv install 3.7.0
+            pyenv global 3.7.0
             ;;
         pypy*)
             pyenv install "$PYPY_VERSION"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ The release versions are PyPi releases.
 
 ## Version 3.5 (as yet unreleased)
 
+This version of pyfakefs does not support Python 3.3. Python 3.3 users shall 
+keep using pyfakefs 3.4.3, or upgrade to a newer Python version.
+
 #### New Features
   * parameter `patch_path` has been removed from `UnitTest` and `Patcher`, 
     the correct patching of `path` imports is now done automatically

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ using convenience functions.
 ## Installation
 
 ### Compatibility
-pyfakefs works with CPython 2.7, 3.3 and above, on Linux, Windows and OSX (MacOS), and with PyPy2 and PyPy3.
+pyfakefs works with CPython 2.7, 3.4 and above, on Linux, Windows and OSX 
+(MacOS), and with PyPy2 and PyPy3.
 
 pyfakefs works with [PyTest](http://doc.pytest.org) version 2.8.6 or above.
 
@@ -59,10 +60,10 @@ For example, pyfakefs will not work with [`lxml`](http://lxml.de/).  In this cas
 ### Continuous integration
 
 pyfakefs is currently automatically tested:
-* On Linux, with Python 2.7, 3.3 and above using [Travis](https://travis-ci.org/jmcgeheeiv/pyfakefs)
-* On MacOS, with Python 2.7 and 3.6, also using [Travis](https://travis-ci.org/jmcgeheeiv/pyfakefs).
+* On Linux, with Python 2.7, and 3.4 to 3.7, using [Travis](https://travis-ci.org/jmcgeheeiv/pyfakefs)
+* On MacOS, with Python 2.7, 3.6 and 3.7, also using [Travis](https://travis-ci.org/jmcgeheeiv/pyfakefs).
   The Linux/MacOS build is currently [![Build Status](https://travis-ci.org/jmcgeheeiv/pyfakefs.svg)](https://travis-ci.org/jmcgeheeiv/pyfakefs).
-* On Windows, with Python 2.7, 3.4 and above using [Appveyor](https://ci.appveyor.com/project/jmcgeheeiv/pyfakefs).
+* On Windows, with Python 2.7, and 3.4 to 3.7 using [Appveyor](https://ci.appveyor.com/project/jmcgeheeiv/pyfakefs).
   The Windows build is currently [![Build status](https://ci.appveyor.com/api/projects/status/4o8j21ufuo056873/branch/master?svg=true)](https://ci.appveyor.com/project/jmcgeheeiv/pyfakefs/branch/master).
 
 ### Running pyfakefs unit tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,8 @@ Introduction
 Using pyfakefs, your tests operate on a fake file system in memory without touching the real disk.
 The software under test requires no modification to work with pyfakefs.
 
-pyfakefs works with CPython 2.7, 3.3 and above, on Linux, Windows and OSX (MacOS), and with PyPy2 and PyPy3.
+pyfakefs works with CPython 2.7, 3.4 and above, on Linux, Windows and OSX
+(MacOS), and with PyPy2 and PyPy3.
 
 pyfakefs works with `PyTest <doc.pytest.org>`__ version 2.8.6 or above.
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ CLASSIFIERS = [
     'License :: OSI Approved :: Apache Software License',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
- added 3.7 builds for MacOS and Windows
- use released 3.7 build for Linux
- closes #436