### PR TITLE
Fix pytest when pyfakefs + future is installed

### DIFF
--- a/pyfakefs/pytest_plugin.py
+++ b/pyfakefs/pytest_plugin.py
@@ -10,15 +10,16 @@ def my_fakefs_test(fs):
 """
 
 import linecache
+import sys
 
 import py
 import pytest
 
 from pyfakefs.fake_filesystem_unittest import Patcher
 
-try:
+if sys.version_info >= (3,):
     import builtins
-except ImportError:
+else:
     import __builtin__ as builtins
 
 Patcher.SKIPMODULES.add(py)  # Ignore pytest components when faking filesystem


### PR DESCRIPTION
`python-future` is notorious for breaking modules which use `try:` / `except:`
to import modules based on version.  In this case, `pyfakefs` imported the
backported `builtins` module which changes the semantics of the `open()`
function.  `pyfakefs` then monkeypatches `linecache` which breaks any module
which attempts to use `linecache` (in this case `pytest`).

The downstream issue is https://github.com/pytest-dev/pytest/pull/4074