### PR TITLE
Added automatic patching of builtin open as other name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ The release versions are PyPi releases.
 
 #### New Features
   * automatically patch file system methods imported as another name like 
-    `from os.path import exists as my_exists`
+    `from os.path import exists as my_exists`, including builtin `open` 
 
 #### Fixes
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -4528,6 +4528,13 @@ class FakeIoModule(object):
     my_io_module = fake_filesystem.FakeIoModule(filesystem)
     """
 
+    @staticmethod
+    def dir():
+        """Return the list of patched function names. Used for patching
+        functions imported from the module.
+        """
+        return 'open',
+
     def __init__(self, filesystem):
         """
         Args:
@@ -4551,6 +4558,24 @@ class FakeIoModule(object):
     def __getattr__(self, name):
         """Forwards any unfaked calls to the standard io module."""
         return getattr(self._io_module, name)
+
+
+class FakeBuiltinModule(object):
+    """Uses FakeFilesystem to provide a fake built-in open replacement.
+    """
+    def __init__(self, filesystem):
+        """
+        Args:
+            filesystem: FakeFilesystem used to provide
+                file system information.
+        """
+        self.filesystem = filesystem
+
+    def open(self, *args, **kwargs):
+        """Redirect the call to FakeFileOpen.
+        See FakeFileOpen.call() for description.
+        """
+        return FakeFileOpen(self.filesystem)(*args, **kwargs)
 
 
 class FakeFileWrapper(object):

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -13,6 +13,7 @@
 """Helper classes use for fake file system implementation."""
 import io
 import locale
+import platform
 import sys
 from copy import copy
 from stat import S_IFLNK
@@ -20,7 +21,7 @@ from stat import S_IFLNK
 import os
 
 IS_PY2 = sys.version_info[0] < 3
-
+IS_PYPY = platform.python_implementation() == 'PyPy'
 
 try:
     text_type = unicode  # Python 2

--- a/pyfakefs/tests/example.py
+++ b/pyfakefs/tests/example.py
@@ -29,8 +29,8 @@ The modules related to file handling are bound to the respective fake modules:
 
 The `open()` built-in is bound to the fake `open()`:
 
->>> open     #doctest: +ELLIPSIS
-<pyfakefs.fake_filesystem.FakeFileOpen object...>
+>>> open      #doctest: +ELLIPSIS
+<bound method Fake...Module.open of <pyfakefs.fake_filesystem.Fake...>
 
 In Python 2 the `file()` built-in is also bound to the fake `open()`.  `file()`
 was eliminated in Python 3.

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -33,6 +33,7 @@ from pyfakefs import fake_filesystem_unittest, fake_filesystem
 from pyfakefs.extra_packages import pathlib
 from pyfakefs.fake_filesystem_unittest import Patcher
 import pyfakefs.tests.import_as_example
+from pyfakefs.helpers import IS_PYPY, IS_PY2
 from pyfakefs.tests.fixtures import module_with_attributes
 
 
@@ -54,7 +55,7 @@ class TestPyfakefsUnittestBase(fake_filesystem_unittest.TestCase):
 class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
     """Test the `pyfakefs.fake_filesystem_unittest.TestCase` base class."""
 
-    @unittest.skipIf(sys.version_info > (2,),
+    @unittest.skipIf(sys.version_info[0] > 2,
                      "file() was removed in Python 3")
     def test_file(self):
         """Fake `file()` function is bound"""
@@ -184,6 +185,19 @@ class TestPatchingImports(TestPyfakefsUnittestBase):
         self.fs.create_file(file_path, contents=b'abc')
         stat_result = pyfakefs.tests.import_as_example.file_stat2(file_path)
         self.assertEqual(3, stat_result.st_size)
+
+    @unittest.skipIf(IS_PYPY and IS_PY2, 'Not working for PyPy2')
+    def test_import_open_as_other_name(self):
+        file_path = '/foo/bar'
+        self.fs.create_file(file_path, contents=b'abc')
+        contents = pyfakefs.tests.import_as_example.file_contents1(file_path)
+        self.assertEqual('abc', contents)
+
+    def test_import_io_open_as_other_name(self):
+        file_path = '/foo/bar'
+        self.fs.create_file(file_path, contents=b'abc')
+        contents = pyfakefs.tests.import_as_example.file_contents2(file_path)
+        self.assertEqual('abc', contents)
 
 
 class TestAttributesWithFakeModuleNames(TestPyfakefsUnittestBase):

--- a/pyfakefs/tests/import_as_example.py
+++ b/pyfakefs/tests/import_as_example.py
@@ -20,6 +20,12 @@ from os import stat
 from os import stat as my_stat
 from os.path import exists
 from os.path import exists as my_exists
+from io import open as io_open
+
+try:
+    from builtins import open as bltn_open
+except ImportError:
+    from __builtin__ import open as bltn_open
 
 import sys
 
@@ -79,3 +85,13 @@ def system_stat(filepath):
     else:
         from posix import stat as system_stat
     return system_stat(filepath)
+
+
+def file_contents1(filepath):
+    with bltn_open(filepath) as f:
+        return f.read()
+
+
+def file_contents2(filepath):
+    with io_open(filepath) as f:
+        return f.read()


### PR DESCRIPTION
- in Python 2, builtin open is now handled by FakeBuiltinModule 
- in Python 3, builtin open is handled via io.open
- adapted pytest plugin to ensure that open is not patched
  for linecache and dependent tokenize modules
- importing builtin open as other name does not work with PyPy2
- see #449