### PR TITLE
FakeIOModule.open argument renaming: file_name to file

### DIFF
--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -4553,7 +4553,7 @@ class FakeIoModule(object):
         self.filesystem = filesystem
         self._io_module = io
 
-    def open(self, file_path, mode='r', buffering=-1, encoding=None,
+    def open(self, file, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None, closefd=True, opener=None):
         """Redirect the call to FakeFileOpen.
         See FakeFileOpen.call() for description.
@@ -4562,7 +4562,7 @@ class FakeIoModule(object):
             raise TypeError(
                 "open() got an unexpected keyword argument 'opener'")
         fake_open = FakeFileOpen(self.filesystem, use_io=True)
-        return fake_open(file_path, mode, buffering, encoding, errors,
+        return fake_open(file, mode, buffering, encoding, errors,
                          newline, closefd, opener)
 
     def __getattr__(self, name):


### PR DESCRIPTION
Changed argument name in `FakeIOModule.open` from `file_name` to `file`.
It makes pyfakefs compatible with the library atomicwrites that uses `kwargs` to pass arguments to `io.open` function.
See https://github.com/untitaker/python-atomicwrites/blob/890e7aed4a1fd3b3724dc64503757617996c3978/atomicwrites/__init__.py#L180

In python documentation argument is also named `file`:
py3: https://docs.python.org/3/library/functions.html#open
py2: https://docs.python.org/2.7/library/io.html#io.open