### PR TITLE
Use snapshot of modules to avoid RuntimeError

### DIFF
--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -461,7 +461,7 @@ class Patcher(object):
                 return False
 
         module_names = list(self._fake_module_classes.keys()) + [PATH_MODULE]
-        for name, module in set(sys.modules.items()):
+        for name, module in list(sys.modules.items()):
             try:
                 if (module in self.SKIPMODULES or
                         not inspect.ismodule(module) or


### PR DESCRIPTION
When running code on Python 3.7.3, we get this error intermittently: RuntimeError: dictionary changed size during iteration
Creating a list instead of set appears to solve this issue.