### PR TITLE
Use the current pyfakefs branch in docker file

### DIFF
--- a/.travis/docker_tests.sh
+++ b/.travis/docker_tests.sh
@@ -3,6 +3,8 @@
 if [[ $VM == 'Docker' ]]; then
     echo "Running tests in Docker image"
     echo "============================="
-    docker build -t pyfakefs .
+    export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+    export REPO_SLUG=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_REPO_SLUG; else echo $TRAVIS_PULL_REQUEST_SLUG; fi)
+    docker build -t pyfakefs . --build-arg github_repo=$REPO_SLUG --build-arg github_branch=$BRANCH
     docker run -t pyfakefs
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+ARG github_repo=jmcgeheeiv/pyfakefs
+ARG github_branch=master
 
 RUN apt-get update && apt-get install -y \
     python3-pip \
@@ -41,14 +43,13 @@ RUN apt-get clean
 
 RUN useradd -u 1000 pyfakefs
 
-RUN wget https://github.com/jmcgeheeiv/pyfakefs/archive/master.zip \
-    && unzip master.zip \
-    && chown -R pyfakefs:pyfakefs /pyfakefs-master
-WORKDIR /pyfakefs-master
+RUN wget https://github.com/$github_repo/archive/$github_branch.zip \
+    && unzip $github_branch.zip \
+    && chown -R pyfakefs:pyfakefs /pyfakefs-$github_branch
+WORKDIR /pyfakefs-$github_branch
 RUN pip3 install -r requirements.txt
 RUN pip3 install -r extra_requirements.txt
 
 USER pyfakefs
-ENV PYTHONPATH /pyfakefs-master
+ENV PYTHONPATH /pyfakefs-$github_branch
 CMD ["python3", "-m", "pyfakefs.tests.all_tests"]
-

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -1047,7 +1047,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.assertTrue(self.os.path.exists(link_path))
 
     def test_hardlink_works_with_symlink(self):
-        self.check_posix_only()
+        self.skip_if_symlink_not_supported()
         base_path = self.make_path('foo')
         self.create_dir(base_path)
         symlink_path = self.os.path.join(base_path, 'slink')
@@ -3216,7 +3216,7 @@ class FakeOsModuleTestCaseInsensitiveFS(FakeOsModuleTestBase):
         self.os.stat(path)
 
     def test_hardlink_works_with_symlink(self):
-        self.check_posix_only()
+        self.skip_if_symlink_not_supported()
         base_path = self.make_path('foo')
         self.create_dir(base_path)
         symlink_path = self.os.path.join(base_path, 'slink')


### PR DESCRIPTION
- still defaults to master if docker is build without arguments

Just testing if it works with PR - which it does not... gets the wrong repo user name. 
Ok, fixed.