### PR TITLE
Unload all modules loaded during the test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,9 +14,9 @@ the proposed changes so you can be ready.
 
 ### Fixes
   * fixed side effect of calling `DirEntry.stat()` under Windows (changed 
-    st_nlink) ([#502](../../issues/502))
-  * fixed a problem related to patching `distutils` functions
-    ([#501](../../issues/501))
+    st_nlink) (see [#502](../../issues/502))
+  * fixed problem of fake modules still referenced after a test in modules 
+    loaded during the test (see [#501](../../issues/501) and [#427](../../issues/427))
   * correctly handle missing read permission for parent directory
     (see [#496](../../issues/496))
   * raise for `os.scandir` with non-existing directory

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -667,8 +667,9 @@ class DynamicPatcher(object):
                 reload(module)
         reloaded_module_names = [module.__name__
                                  for module in self._patcher.modules_to_reload]
-        # force all modules loaded during the test to reload on next use,
-        # to ensure that no faked modules are still hold in these modules
+        # Dereference all modules loaded during the test so they will reload on
+        # the next use, ensuring that no faked modules are referenced after the
+        # test.
         for name in self._loaded_module_names:
             if name in sys.modules and name not in reloaded_module_names:
                 del sys.modules[name]

--- a/pyfakefs/tests/dynamic_patch_test.py
+++ b/pyfakefs/tests/dynamic_patch_test.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 """
-Tests for patching modules loaded after `setupPyfakefs()`.
+Tests for patching modules loaded after `setUpPyfakefs()`.
 """
 import sys
 import unittest


### PR DESCRIPTION
- these module can still hold references to fake modules
- modules already loaded at test start are not affected
- see #501 and #427