### PR TITLE
Remove @DeprecationWarning as it isn't a decorator

### DIFF
--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -329,7 +329,6 @@ class TestCase(unittest.TestCase, TestCaseMixin):
                              "supports NOT creating missing directories")
         return self._stubber.fs.add_real_file(real_file_path, read_only=False)
 
-    @DeprecationWarning
     def tearDownPyfakefs(self):
         """This method is deprecated and exists only for backward
         compatibility. It does nothing.


### PR DESCRIPTION
`tearDownPyfakefs` is a no-op legacy API, it was given @DeprecationWarning as a decorator... which broke it rather than making it a no-op callable as that isn't a decorator.

This fixes:

```
    self.tearDownPyfakefs()
TypeError: 'DeprecationWarning' object is not callable
```

in code updating to a modern pyfakefs that still calls it.