### PR TITLE
fix breaking pathlib change in 3.10 beta1

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-2016]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-beta.1]
         include:
           - python-version: pypy3
             os: ubuntu-latest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,18 +79,28 @@ jobs:
       shell: bash
     - name: Install extra dependencies
       run: |
-        pip install -r extra_requirements.txt
+        # some extra dependencies are not avaialble in 3.10 Beta yet
+        # so we exclude it from all tests on extra dependencies
+        if [[ '${{ matrix.python-version }}' != '3.10.0-beta.1' ]]; then
+          pip install -r extra_requirements.txt
+        fi
+      shell: bash
     - name: Run unit tests with extra packages as non-root user
       run: |
-        python -m pyfakefs.tests.all_tests
+        if [[ '${{ matrix.python-version }}' != '3.10.0-beta.1' ]]; then
+          python -m pyfakefs.tests.all_tests
+        fi
+      shell: bash
     - name: Run pytest tests
       run: |
-        export PY_VERSION=${{ matrix.python-version }}
-        $GITHUB_WORKSPACE/.github/workflows/run_pytest.sh
+        if [[ '${{ matrix.python-version }}' != '3.10.0-beta.1' ]]; then
+          export PY_VERSION=${{ matrix.python-version }}
+          $GITHUB_WORKSPACE/.github/workflows/run_pytest.sh
+        fi
       shell: bash
     - name: Run performance tests
       run: |
-        if [[ '${{ matrix.os  }}' != 'macOS-latest' ]]; then
+        if [[ '${{ matrix.os  }}' != 'macOS-latest' && '${{ matrix.python-version }}' != '3.10.0-beta.1' ]]; then
           export TEST_PERFORMANCE=1
           python -m pyfakefs.tests.performance_test
         fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,6 @@ The released versions correspond to PyPi releases.
 ### Fixes
   * correctly handle byte paths in `os.path.exists`
     (see [#595](../../issues/595))
-
-### Fixes
   * Update `fake_pathlib` to support changes coming in Python 3.10
     ([see](https://github.com/python/cpython/pull/19342))
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@ The released versions correspond to PyPi releases.
   * correctly handle byte paths in `os.path.exists`
     (see [#595](../../issues/595))
 
+### Fixes
+  * Update `fake_pathlib` to support changes coming in Python 3.10
+    ([see](https://github.com/python/cpython/pull/19342))
+
 ## [Version 4.4.0](https://pypi.python.org/pypi/pyfakefs/4.4.0) (2021-02-24)
 Adds better support for Python 3.8 / 3.9.
   

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -114,7 +114,7 @@ from pyfakefs.fake_scandir import scandir, walk
 from pyfakefs.helpers import (
     FakeStatResult, BinaryBufferIO, TextBufferIO,
     is_int_type, is_byte_string, is_unicode_string,
-    make_string_path, IS_WIN, to_string, matching_string
+    make_string_path, IS_WIN, to_string, matching_string, real_encoding
 )
 from pyfakefs import __version__  # noqa: F401 for upwards compatibility
 
@@ -293,7 +293,7 @@ class FakeFile:
         if st_mode >> 12 == 0:
             st_mode |= S_IFREG
         self.stat_result.st_mode = st_mode
-        self.encoding = encoding
+        self.encoding = real_encoding(encoding)
         self.errors = errors or 'strict'
         self._byte_contents = self._encode_contents(contents)
         self.stat_result.st_size = (
@@ -430,7 +430,7 @@ class FakeFile:
           OSError: if `st_size` is not a non-negative integer,
                    or if it exceeds the available file system space.
         """
-        self.encoding = encoding
+        self.encoding = real_encoding(encoding)
         changed = self._set_initial_contents(contents)
         if self._side_effect is not None:
             self._side_effect(self)

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1177,9 +1177,12 @@ class FakeFilesystem:
             OSError: if the filesystem object doesn't exist.
         """
         # stat should return the tuple representing return value of os.stat
-        file_object = self.resolve(
-            entry_path, follow_symlinks,
-            allow_fd=True, check_read_perm=False)
+        try:
+            file_object = self.resolve(
+                entry_path, follow_symlinks,
+                allow_fd=True, check_read_perm=False)
+        except TypeError:
+            file_object = self.resolve(entry_path)
         if not is_root():
             # make sure stat raises if a parent dir is not readable
             parent_dir = file_object.parent_dir

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -134,6 +134,9 @@ class _FakeAccessor(accessor):
             lambda fs, file_path, link_target:
             FakeFilesystem.link(fs, file_path, link_target))
 
+        # this will use the fake filesystem because os is patched
+        getcwd = lambda p: os.getcwd()
+
     readlink = _wrap_strfunc(FakeFilesystem.readlink)
 
     utime = _wrap_strfunc(FakeFilesystem.utime)

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -53,8 +53,8 @@ def init_module(filesystem):
 
 def _wrap_strfunc(strfunc):
     @functools.wraps(strfunc)
-    def _wrapped(pathobj, *args):
-        return strfunc(pathobj.filesystem, str(pathobj), *args)
+    def _wrapped(pathobj, *args, **kwargs):
+        return strfunc(pathobj.filesystem, str(pathobj), *args, **kwargs)
 
     return staticmethod(_wrapped)
 
@@ -461,18 +461,14 @@ class FakePath(pathlib.Path):
             cls = (FakePathlibModule.WindowsPath
                    if cls.filesystem.is_windows_fs
                    else FakePathlibModule.PosixPath)
-        self = cls._from_parts(args, init=True)
+        self = cls._from_parts(args)
+        self._accessor = _fake_accessor
         return self
 
     def _path(self):
         """Returns the underlying path string as used by the fake filesystem.
         """
         return str(self)
-
-    def _init(self, template=None):
-        """Initializer called from base class."""
-        self._accessor = _fake_accessor
-        self._closed = False
 
     @classmethod
     def cwd(cls):
@@ -722,7 +718,8 @@ class RealPath(pathlib.Path):
         if cls is RealPathlibModule.Path:
             cls = (RealPathlibModule.WindowsPath if os.name == 'nt'
                    else RealPathlibModule.PosixPath)
-        self = cls._from_parts(args, init=True)
+        self = cls._from_parts(args)
+        self._accessor = _fake_accessor
         return self
 
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -463,6 +463,7 @@ class FakePath(pathlib.Path):
                    else FakePathlibModule.PosixPath)
         self = cls._from_parts(args)
         self._accessor = _fake_accessor
+        self._closed = False
         return self
 
     def _path(self):
@@ -720,6 +721,7 @@ class RealPath(pathlib.Path):
                    else RealPathlibModule.PosixPath)
         self = cls._from_parts(args)
         self._accessor = _fake_accessor
+        self._closed = False
         return self
 
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -462,9 +462,15 @@ class FakePath(pathlib.Path):
                    if cls.filesystem.is_windows_fs
                    else FakePathlibModule.PosixPath)
         self = cls._from_parts(args)
-        self._accessor = _fake_accessor
-        self._closed = False
+        self._init()
         return self
+
+    def _init(self, template=None):
+         """Initializer called from base class."""
+         # template is an unused holdover
+         _ = template
+         self._accessor = _fake_accessor
+         self._closed = False
 
     def _path(self):
         """Returns the underlying path string as used by the fake filesystem.
@@ -720,8 +726,7 @@ class RealPath(pathlib.Path):
             cls = (RealPathlibModule.WindowsPath if os.name == 'nt'
                    else RealPathlibModule.PosixPath)
         self = cls._from_parts(args)
-        self._accessor = _fake_accessor
-        self._closed = False
+        self._init()
         return self
 
 

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -57,6 +57,15 @@ def to_string(path):
     return path
 
 
+def real_encoding(encoding):
+    """Since Python 3.10, the new function ``io.text_encoding`` returns
+    "locale" as the encoding if None is defined. This will be handled
+    as no encoding in pyfakefs."""
+    if sys.version_info >= (3, 10):
+        return encoding if encoding != "locale" else None
+    return encoding
+
+
 def matching_string(matched, string):
     """Return the string as byte or unicode depending
     on the type of matched, assuming string is an ASCII string.

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -970,7 +970,22 @@ class FakePathlibUsageInOsFunctionsTest(RealPathlibTestCase):
     def test_stat(self):
         path = self.make_path('foo', 'bar', 'baz')
         self.create_file(path, contents='1234567')
-        self.assertEqual(self.os.stat(path), self.os.stat(self.path(path)))
+        self.assertEqual(self.os.stat(path), self.path(path).stat())
+
+    @unittest.skipIf(sys.version_info < (3, 10), "New in Python 3.10")
+    def test_stat_follow_symlinks(self):
+        self.check_posix_only()
+        directory = self.make_path('foo')
+        base_name = 'bar'
+        file_path = self.path(self.os.path.join(directory, base_name))
+        link_path = self.path(self.os.path.join(directory, 'link'))
+        contents = "contents"
+        self.create_file(file_path, contents=contents)
+        self.create_symlink(link_path, base_name)
+        self.assertEqual(len(contents),
+                         link_path.stat(follow_symlinks=True)[stat.ST_SIZE])
+        self.assertEqual(len(base_name),
+                         link_path.stat(follow_symlinks=False)[stat.ST_SIZE])
 
     def test_utime(self):
         path = self.make_path('some_file')

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -380,9 +380,12 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
 
     def test_lchmod(self):
         self.skip_if_symlink_not_supported()
+        if (sys.version_info >= (3, 10) and self.use_real_fs() and
+                'chmod' not in os.supports_follow_symlinks):
+            raise unittest.SkipTest('follow_symlinks not available for chmod')
         file_stat = self.os.stat(self.file_path)
         link_stat = self.os.lstat(self.file_link_path)
-        if not hasattr(os, "lchmod") and sys.version_info < (3, 10):
+        if not hasattr(os, "lchmod"):
             with self.assertRaises(NotImplementedError):
                 self.path(self.file_link_path).lchmod(0o444)
         else:

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -378,20 +378,19 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
         # we get stat.S_IFLNK | 0o755 under MacOs
         self.assertEqual(link_stat.st_mode, stat.S_IFLNK | 0o777)
 
-    @unittest.skipIf(sys.platform == 'darwin',
-                     'Different behavior under MacOs')
     def test_lchmod(self):
         self.skip_if_symlink_not_supported()
         file_stat = self.os.stat(self.file_path)
         link_stat = self.os.lstat(self.file_link_path)
-        if not hasattr(os, "lchmod"):
+        if not hasattr(os, "lchmod") and sys.version_info < (3, 10):
             with self.assertRaises(NotImplementedError):
                 self.path(self.file_link_path).lchmod(0o444)
         else:
             self.path(self.file_link_path).lchmod(0o444)
             self.assertEqual(file_stat.st_mode, stat.S_IFREG | 0o666)
-            # we get stat.S_IFLNK | 0o755 under MacOs
-            self.assertEqual(link_stat.st_mode, stat.S_IFLNK | 0o444)
+            # the exact mode depends on OS and Python version
+            self.assertEqual(link_stat.st_mode & 0o777700,
+                             stat.S_IFLNK | 0o700)
 
     def test_resolve(self):
         self.create_dir(self.make_path('antoine', 'docs'))


### PR DESCRIPTION
Hello!

Sorry for the PR outa the blue w/out an issue to discuss -- had some time and figured I'd take a crack at it. I added 3.10 beta1 to my ci for some projects using pyfakefs and my builds are failing. Did a bit of sleuthing and it seems there were a few changes to Pathlib for this release. The main issue/thread seems to be [here](https://github.com/python/cpython/pull/19342) -- and associated [commit](https://github.com/python/cpython/commit/2219187cab6bca009c42b63b2f4c30b5b10c916d). This [commit](https://github.com/python/cpython/commit/abf964942f97f6489360a75fd57b5e4f41c75f57) also appears to be related.

I *think* (hope?!) that this fix is backwards compatible. Tests in the docker container all seem happy, and I've tested this locally on my Mac w/ 3.10 beta1 and the tests that are/were failing in CI pass like normal. For reference, [here](https://github.com/scrapli/scrapli_cfg/runs/2547508032?check_suite_focus=true) is my failed tests (the `build_posix (ubuntu-latest, 3.10.0-beta.1)` job). 

The fix itself is basically to ignore that `init` argument (the pr/issue on Cpython seems to say this is mostly legacy and (obviously) going away anyway). Then allowing the wrapped stat method (well I guess everything... which is perhaps not ideal?) to accept kwargs as well. Since `_init` method is no longer called, I removed that and just assigned that `_accessor` to the `_fake_accessor` directly after the `_from_parts` calls. 

Hope that all makes sense -- have been happily using pyfakefs (thanks for the project btw!) a while but the guts of it are probably a bit over my head :)

Carl