### PR TITLE
Ascola/add type checking

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,31 @@
+[mypy]
+show_error_codes = True
+warn_unused_configs = True
+exclude=(docs|pyfakefs/tests)
+
+[mypy-django.*]
+ignore_missing_imports = True
+
+[mypy-hotshot.*]
+ignore_missing_imports = True
+
+[mypy-openpyxl.*]
+ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-pathlib2.*]
+ignore_missing_imports = True
+
+[mypy-psyco.*]
+ignore_missing_imports = True
+
+[mypy-scandir.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-xlrd.*]
+ignore_missing_imports = True

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -128,7 +128,7 @@ PERM_DEF_FILE = 0o666  # Default permission bits (regular file)
 PERM_ALL = 0o7777  # All permission bits.
 
 _OpenModes = namedtuple(
-    'open_modes',
+    '_OpenModes',
     'must_exist can_read can_write truncate append must_not_exist'
 )
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -442,6 +442,31 @@ class FakeFile:
         """
         return self.st_size
 
+    @size.setter
+    def size(self, st_size):
+        """Resizes file content, padding with nulls if new size exceeds the
+        old size.
+
+        Args:
+          st_size: The desired size for the file.
+
+        Raises:
+          OSError: if the st_size arg is not a non-negative integer
+                   or if st_size exceeds the available file system space
+        """
+
+        self._check_positive_int(st_size)
+        current_size = self.st_size or 0
+        self.filesystem.change_disk_usage(
+            st_size - current_size, self.name, self.st_dev)
+        if self._byte_contents:
+            if st_size < current_size:
+                self._byte_contents = self._byte_contents[:st_size]
+            else:
+                self._byte_contents += b'\0' * (st_size - current_size)
+        self.st_size = st_size
+        self.epoch += 1
+
     @property
     def path(self):
         """Return the full path of the current object."""
@@ -471,31 +496,6 @@ class FakeFile:
     @Deprecator('property size')
     def GetSize(self):
         return self.size
-
-    @size.setter
-    def size(self, st_size):
-        """Resizes file content, padding with nulls if new size exceeds the
-        old size.
-
-        Args:
-          st_size: The desired size for the file.
-
-        Raises:
-          OSError: if the st_size arg is not a non-negative integer
-                   or if st_size exceeds the available file system space
-        """
-
-        self._check_positive_int(st_size)
-        current_size = self.st_size or 0
-        self.filesystem.change_disk_usage(
-            st_size - current_size, self.name, self.st_dev)
-        if self._byte_contents:
-            if st_size < current_size:
-                self._byte_contents = self._byte_contents[:st_size]
-            else:
-                self._byte_contents += b'\0' * (st_size - current_size)
-        self.st_size = st_size
-        self.epoch += 1
 
     @Deprecator('property size')
     def SetSize(self, value):
@@ -746,6 +746,10 @@ class FakeDirectory(FakeFile):
         """
         return sum([item[1].size for item in self.contents.items()])
 
+    @size.setter
+    def size(self, st_size):
+        super().size(st_size)
+
     @Deprecator('property size')
     def GetSize(self):
         return self.size
@@ -840,6 +844,10 @@ class FakeDirectoryFromRealDirectory(FakeDirectory):
         if not self.contents_read:
             return 0
         return super(FakeDirectoryFromRealDirectory, self).size
+
+    @size.setter
+    def size(self, st_size):
+        super().size(st_size)
 
 
 class FakeFilesystem:

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -322,25 +322,25 @@ class FakeFile:
         """Return the creation time of the fake file."""
         return self.stat_result.st_ctime
 
-    @property
-    def st_atime(self):
-        """Return the access time of the fake file."""
-        return self.stat_result.st_atime
-
-    @property
-    def st_mtime(self):
-        """Return the modification time of the fake file."""
-        return self.stat_result.st_mtime
-
     @st_ctime.setter
     def st_ctime(self, val):
         """Set the creation time of the fake file."""
         self.stat_result.st_ctime = val
 
+    @property
+    def st_atime(self):
+        """Return the access time of the fake file."""
+        return self.stat_result.st_atime
+
     @st_atime.setter
     def st_atime(self, val):
         """Set the access time of the fake file."""
         self.stat_result.st_atime = val
+
+    @property
+    def st_mtime(self):
+        """Return the modification time of the fake file."""
+        return self.stat_result.st_mtime
 
     @st_mtime.setter
     def st_mtime(self, val):

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -43,6 +43,8 @@ import shutil
 import sys
 import tempfile
 import tokenize
+from types import ModuleType
+from typing import Any, Callable, Dict, List, Set, Tuple
 import unittest
 import warnings
 
@@ -366,11 +368,11 @@ class Patcher:
     }
     # caches all modules that do not have file system modules or function
     # to speed up _find_modules
-    CACHED_MODULES = set()
-    FS_MODULES = {}
-    FS_FUNCTIONS = {}
-    FS_DEFARGS = []
-    SKIPPED_FS_MODULES = {}
+    CACHED_MODULES: Set[ModuleType] = set()
+    FS_MODULES: Dict[str, Set[ModuleType]] = {}
+    FS_FUNCTIONS: Dict[Tuple[str, str, str], Set[ModuleType]] = {}
+    FS_DEFARGS: List[Tuple[Callable[..., Any], int, Callable[..., Any]]] = []
+    SKIPPED_FS_MODULES: Dict[str, Set[ModuleType]] = {}
 
     assert None in SKIPMODULES, ("sys.modules contains 'None' values;"
                                  " must skip them.")
@@ -380,8 +382,8 @@ class Patcher:
     SKIPNAMES = {'os', 'path', 'io', 'genericpath', OS_MODULE, PATH_MODULE}
 
     # hold values from last call - if changed, the cache has to be invalidated
-    PATCHED_MODULE_NAMES = {}
-    ADDITIONAL_SKIP_NAMES = set()
+    PATCHED_MODULE_NAMES: Set[str] = set()
+    ADDITIONAL_SKIP_NAMES: Set[str] = set()
     PATCH_DEFAULT_ARGS = False
 
     def __init__(self, additional_skip_names=None,

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -56,7 +56,7 @@ from pyfakefs.patched_packages import (
 try:
     from importlib.machinery import ModuleSpec
 except ImportError:
-    ModuleSpec = object
+    ModuleSpec = object  # type: ignore [assignment, misc]
 
 from importlib import reload
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -83,7 +83,7 @@ except AttributeError:
     accessor = object
 
 
-class _FakeAccessor(accessor):
+class _FakeAccessor(accessor):  # type: ignore [valid-type, misc]
     """Accessor which forwards some of the functions to FakeFilesystem methods.
     """
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -78,7 +78,7 @@ def _wrap_binary_strfunc_reverse(strfunc):
 
 
 try:
-    accessor = pathlib._Accessor
+    accessor = pathlib._Accessor  # type: ignore [attr-defined]
 except AttributeError:
     accessor = object
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -157,7 +157,7 @@ class _FakeAccessor(accessor):  # type: ignore [valid-type, misc]
 
 _fake_accessor = _FakeAccessor()
 
-flavour = pathlib._Flavour
+flavour = pathlib._Flavour  # type: ignore [attr-defined]
 
 
 class _FakeFlavour(flavour):

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -160,7 +160,7 @@ _fake_accessor = _FakeAccessor()
 flavour = pathlib._Flavour  # type: ignore [attr-defined]
 
 
-class _FakeFlavour(flavour):
+class _FakeFlavour(flavour):  # type: ignore [valid-type, misc]
     """Fake Flavour implementation used by PurePath and _Flavour"""
 
     filesystem = None

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -33,6 +33,7 @@ import fnmatch
 import functools
 import os
 import pathlib
+from pathlib import PurePath
 import re
 import sys
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
@@ -705,8 +706,6 @@ class FakePathlibModule:
     `fake_pathlib_module = fake_filesystem.FakePathlibModule(filesystem)`
     """
 
-    PurePath = pathlib.PurePath
-
     def __init__(self, filesystem):
         """
         Initializes the module with the given filesystem.
@@ -780,7 +779,6 @@ class RealPathlibModule:
     As the original `pathlib` is always patched to use the fake path,
     we need to provide a version which does not do this.
     """
-    PurePath = pathlib.PurePath
 
     def __init__(self):
         RealPathlibModule.PureWindowsPath._flavour = pathlib._WindowsFlavour()

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -172,27 +172,27 @@ class FakeStatResult:
         ctime = self._st_ctime_ns / 1e9
         return ctime if self.use_float else int(ctime)
 
+    @st_ctime.setter
+    def st_ctime(self, val):
+        """Set the creation time in seconds."""
+        self._st_ctime_ns = int(val * 1e9)
+
     @property
     def st_atime(self):
         """Return the access time in seconds."""
         atime = self._st_atime_ns / 1e9
         return atime if self.use_float else int(atime)
 
+    @st_atime.setter
+    def st_atime(self, val):
+        """Set the access time in seconds."""
+        self._st_atime_ns = int(val * 1e9)
+
     @property
     def st_mtime(self):
         """Return the modification time in seconds."""
         mtime = self._st_mtime_ns / 1e9
         return mtime if self.use_float else int(mtime)
-
-    @st_ctime.setter
-    def st_ctime(self, val):
-        """Set the creation time in seconds."""
-        self._st_ctime_ns = int(val * 1e9)
-
-    @st_atime.setter
-    def st_atime(self, val):
-        """Set the access time in seconds."""
-        self._st_atime_ns = int(val * 1e9)
 
     @st_mtime.setter
     def st_mtime(self, val):
@@ -267,25 +267,25 @@ class FakeStatResult:
         """Return the access time in nanoseconds."""
         return self._st_atime_ns
 
-    @property
-    def st_mtime_ns(self):
-        """Return the modification time in nanoseconds."""
-        return self._st_mtime_ns
-
-    @property
-    def st_ctime_ns(self):
-        """Return the creation time in nanoseconds."""
-        return self._st_ctime_ns
-
     @st_atime_ns.setter
     def st_atime_ns(self, val):
         """Set the access time in nanoseconds."""
         self._st_atime_ns = val
 
+    @property
+    def st_mtime_ns(self):
+        """Return the modification time in nanoseconds."""
+        return self._st_mtime_ns
+
     @st_mtime_ns.setter
     def st_mtime_ns(self, val):
         """Set the modification time of the fake file in nanoseconds."""
         self._st_mtime_ns = val
+
+    @property
+    def st_ctime_ns(self):
+        """Return the creation time in nanoseconds."""
+        return self._st_ctime_ns
 
     @st_ctime_ns.setter
     def st_ctime_ns(self, val):

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from typing import List
 
 from setuptools import setup, find_packages
 
 from pyfakefs import __version__
 
 NAME = 'pyfakefs'
-REQUIRES = []
+REQUIRES: List[str] = []
 DESCRIPTION = ('pyfakefs implements a fake file system that mocks '
                'the Python file system modules.')
 


### PR DESCRIPTION
This PR adds basic support for usage of the tool [mypy](http://mypy-lang.org/), a static type checker for Python. It configures mypy via `mypy.ini` (see https://mypy.readthedocs.io/en/stable/config_file.html for documentation about the configuration files), ignores some reported errors, and adds a few annotations in places where mypy was not able to infer the type of a variable.

For the configuration, I chose to ignore all dependencies for the sake of setting this up. But note that this is not recommended for the long term.

The following is a procedure to run mypy (from the root directory of the repo):
```bash
python3 -m venv type_checking
source type_checking/bin/activate
python3 -m pip install -r requirements.txt -r extra_requirements.txt
python3 -m pip install mypy==0.812
python3 -m mypy .
```

You should see the following for output:
```
Success: no issues found in 24 source files
```

I'm not sure what the plans are for including this in the GitHub Action but I think it probably should be included at some point.

The next steps would be to gradually increase the strictness of mypy via configuration options.

One open question is at what point a `py.typed` file should be included in the package (and `Typing :: Typed` classifier too).