### PR TITLE
Add step to find test dependencies

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -124,3 +124,24 @@ jobs:
           python -m pyfakefs.tests.performance_test
         fi
       shell: bash
+
+  dependency-check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2016]
+        python-version:  [3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r extra_requirements.txt
+          pip install pytest-find-dependencies
+      - name: Check dependencies
+        run: python -m pytest --find-dependencies pyfakefs/tests
+        shell: bash

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ The released versions correspond to PyPi releases.
 
 ## Version 4.6.0 (as yet unreleased)
 
+### Infrastructure
+* added test dependency check (see [#608](../../issues/608))
+
 ## [Version 4.5.0](https://pypi.python.org/pypi/pyfakefs/4.5.0) (2021-06-04)
 Adds some support for Python 3.10 and basic type checking.
 


### PR DESCRIPTION
- see #608

This runs under Windows and Ubuntu, one Python version only, to avoid adding test dependencies in the future.
Also runs all tests using pytest as an added bonus.