### PR TITLE
Require Python >= 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ params = dict(
     keywords=KEYWORDS,
     url=URL,
     classifiers=CLASSIFIERS,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     test_suite='pyfakefs.tests',
     packages=find_packages(exclude=['docs'])
 )


### PR DESCRIPTION
pyfakefs 4.5 removed support for Python 3.5, but the python_requires metadata was not updated to reflect this, which means that pyfakefs can be installed in a Python 3.5 environment but will not run correctly.