### PR TITLE
Deprecate all warnings while inspecting loaded modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The released versions correspond to PyPi releases.
 ### Fixes
 * added handling of path-like where missing
 * improved handling of `str`/`bytes` paths
+* suppress all warnings while inspecting loaded modules
+  (see [#614](../../issues/614))
 
 ### Infrastructure
 * added test dependency check (see [#608](../../issues/608))

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -716,8 +716,7 @@ class Patcher:
         with warnings.catch_warnings():
             # ignore deprecation warnings, see #542
             warnings.filterwarnings(
-                'ignore',
-                category=DeprecationWarning
+                'ignore'
             )
             self._find_modules()
 

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -540,7 +540,15 @@ class NoRootUserTest(fake_filesystem_unittest.TestCase):
             open(file_path, 'w')
 
 
-class PauseResumeTest(TestPyfakefsUnittestBase):
+class PauseResumeTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.real_temp_file = None
+        self.setUpPyfakefs()
+
+    def tearDown(self):
+        if self.real_temp_file is not None:
+            self.real_temp_file.close()
+
     def test_pause_resume(self):
         fake_temp_file = tempfile.NamedTemporaryFile()
         self.assertTrue(self.fs.exists(fake_temp_file.name))
@@ -548,11 +556,11 @@ class PauseResumeTest(TestPyfakefsUnittestBase):
         self.pause()
         self.assertTrue(self.fs.exists(fake_temp_file.name))
         self.assertFalse(os.path.exists(fake_temp_file.name))
-        real_temp_file = tempfile.NamedTemporaryFile()
-        self.assertFalse(self.fs.exists(real_temp_file.name))
-        self.assertTrue(os.path.exists(real_temp_file.name))
+        self.real_temp_file = tempfile.NamedTemporaryFile()
+        self.assertFalse(self.fs.exists(self.real_temp_file.name))
+        self.assertTrue(os.path.exists(self.real_temp_file.name))
         self.resume()
-        self.assertFalse(os.path.exists(real_temp_file.name))
+        self.assertFalse(os.path.exists(self.real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_fs(self):
@@ -565,15 +573,15 @@ class PauseResumeTest(TestPyfakefsUnittestBase):
         self.fs.pause()
         self.assertTrue(self.fs.exists(fake_temp_file.name))
         self.assertFalse(os.path.exists(fake_temp_file.name))
-        real_temp_file = tempfile.NamedTemporaryFile()
-        self.assertFalse(self.fs.exists(real_temp_file.name))
-        self.assertTrue(os.path.exists(real_temp_file.name))
+        self.real_temp_file = tempfile.NamedTemporaryFile()
+        self.assertFalse(self.fs.exists(self.real_temp_file.name))
+        self.assertTrue(os.path.exists(self.real_temp_file.name))
         # pause does nothing if already paused
         self.fs.pause()
-        self.assertFalse(self.fs.exists(real_temp_file.name))
-        self.assertTrue(os.path.exists(real_temp_file.name))
+        self.assertFalse(self.fs.exists(self.real_temp_file.name))
+        self.assertTrue(os.path.exists(self.real_temp_file.name))
         self.fs.resume()
-        self.assertFalse(os.path.exists(real_temp_file.name))
+        self.assertFalse(os.path.exists(self.real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_contextmanager(self):
@@ -583,10 +591,10 @@ class PauseResumeTest(TestPyfakefsUnittestBase):
         with Pause(self):
             self.assertTrue(self.fs.exists(fake_temp_file.name))
             self.assertFalse(os.path.exists(fake_temp_file.name))
-            real_temp_file = tempfile.NamedTemporaryFile()
-            self.assertFalse(self.fs.exists(real_temp_file.name))
-            self.assertTrue(os.path.exists(real_temp_file.name))
-        self.assertFalse(os.path.exists(real_temp_file.name))
+            self.real_temp_file = tempfile.NamedTemporaryFile()
+            self.assertFalse(self.fs.exists(self.real_temp_file.name))
+            self.assertTrue(os.path.exists(self.real_temp_file.name))
+        self.assertFalse(os.path.exists(self.real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_fs_contextmanager(self):
@@ -596,10 +604,10 @@ class PauseResumeTest(TestPyfakefsUnittestBase):
         with Pause(self.fs):
             self.assertTrue(self.fs.exists(fake_temp_file.name))
             self.assertFalse(os.path.exists(fake_temp_file.name))
-            real_temp_file = tempfile.NamedTemporaryFile()
-            self.assertFalse(self.fs.exists(real_temp_file.name))
-            self.assertTrue(os.path.exists(real_temp_file.name))
-        self.assertFalse(os.path.exists(real_temp_file.name))
+            self.real_temp_file = tempfile.NamedTemporaryFile()
+            self.assertFalse(self.fs.exists(self.real_temp_file.name))
+            self.assertTrue(os.path.exists(self.real_temp_file.name))
+        self.assertFalse(os.path.exists(self.real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_without_patcher(self):
@@ -623,6 +631,7 @@ class PauseResumePatcherTest(fake_filesystem_unittest.TestCase):
             p.resume()
             self.assertFalse(os.path.exists(real_temp_file.name))
             self.assertTrue(os.path.exists(fake_temp_file.name))
+        real_temp_file.close()
 
     def test_pause_resume_contextmanager(self):
         with Patcher() as p:
@@ -637,6 +646,7 @@ class PauseResumePatcherTest(fake_filesystem_unittest.TestCase):
                 self.assertTrue(os.path.exists(real_temp_file.name))
             self.assertFalse(os.path.exists(real_temp_file.name))
             self.assertTrue(os.path.exists(fake_temp_file.name))
+        real_temp_file.close()
 
 
 class TestPyfakefsTestCase(unittest.TestCase):

--- a/pyfakefs/tests/fixtures/deprecated_property.py
+++ b/pyfakefs/tests/fixtures/deprecated_property.py
@@ -21,6 +21,7 @@ class DeprecatedProperty:
 
     def __get__(self, instance, cls):
         warnings.warn("async is deprecated", DeprecationWarning)
+        warnings.warn("async will be replaced", FutureWarning)
         return instance
 
 


### PR DESCRIPTION
- also fix a few resource warnings in unit tests
- fixes #614
