### PR TITLE
Update pandas to version 1.3.1 for Python > 3.6

### DIFF
--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -13,6 +13,7 @@ scandir>=1.8
 # pandas + xlrd are used to test pandas-specific patches to allow
 # pyfakefs to work with pandas
 # we use the latest version to see any problems with new versions
-pandas==1.1.5
+pandas==1.1.5; python_version <= '3.6'
+pandas==1.3.1; python_version > '3.6'
 xlrd==1.2.0
 openpyxl==3.0.7

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -1797,7 +1797,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
             self.os.fsync(test_fd)
             # And just for sanity, double-check that this still raises
             self.assert_raises_os_error(errno.EBADF,
-                                        self.os.fsync, test_fd + 10)
+                                        self.os.fsync, test_fd + 500)
 
     def test_fsync_pass_windows(self):
         self.check_windows_only()
@@ -1809,7 +1809,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
             self.os.fsync(test_fd)
             # And just for sanity, double-check that this still raises
             self.assert_raises_os_error(errno.EBADF,
-                                        self.os.fsync, test_fd + 10)
+                                        self.os.fsync, test_fd + 500)
         with self.open(test_file_path, 'r') as test_file:
             test_fd = test_file.fileno()
             self.assert_raises_os_error(errno.EBADF, self.os.fsync, test_fd)
@@ -1825,7 +1825,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.os.fdatasync(test_fd)
         # And just for sanity, double-check that this still raises
         self.assert_raises_os_error(errno.EBADF,
-                                    self.os.fdatasync, test_fd + 10)
+                                    self.os.fdatasync, test_fd + 500)
 
     def test_access700(self):
         # set up


### PR DESCRIPTION
- make sure the tested invalid file descriptors are out of valid range
 (tests failed in a specific build where the have been to be existing)

