### PR TITLE
Handle pathlib.Path.owner() and pathlib.Path.group()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ The released versions correspond to PyPi releases.
   (see [#614](../../issues/614))
 * do not import pandas and related modules if it is not patched
   (see [#627](../../issues/627))
+* handle `pathlib.Path.owner()` and `pathlib.Path.group` by returning 
+  the current user/group name (see [#629](../../issues/629))
 
 ### Infrastructure
 * added test dependency check (see [#608](../../issues/608))

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -731,11 +731,39 @@ class FakePathlibModule:
         """
         __slots__ = ()
 
+        def owner(self):
+            raise NotImplementedError(
+                "Path.owner() is unsupported on this system")
+
+        def group(self):
+            raise NotImplementedError(
+                "Path.group() is unsupported on this system")
+
+        def is_mount(self):
+            raise NotImplementedError(
+                "Path.is_mount() is unsupported on this system")
+
     class PosixPath(FakePath, PurePosixPath):
         """A subclass of Path and PurePosixPath that represents
         concrete non-Windows filesystem paths.
         """
         __slots__ = ()
+
+        def owner(self):
+            """Return the current user name. It is assumed that the fake
+            file system was created by the current user.
+            """
+            import pwd
+
+            return pwd.getpwuid(os.getuid()).pw_name
+
+        def group(self):
+            """Return the current group name. It is assumed that the fake
+            file system was created by the current user.
+            """
+            import grp
+
+            return grp.getgrgid(os.getgid()).gr_name
 
     Path = FakePath
 

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -1056,6 +1056,24 @@ class FakePathlibUsageInOsFunctionsTest(RealPathlibTestCase):
         st = self.os.stat(path)
         self.assertEqual(4, st.st_size)
 
+    @unittest.skipIf(sys.platform == 'win32',
+                     'no pwd and grp modules in Windows')
+    def test_owner_and_group_posix(self):
+        self.check_posix_only()
+        path = self.make_path('some_file')
+        self.create_file(path)
+        self.assertTrue(self.path(path).owner())
+        self.assertTrue(self.path(path).group())
+
+    def test_owner_and_group_windows(self):
+        self.check_windows_only()
+        path = self.make_path('some_file')
+        self.create_file(path)
+        with self.assertRaises(NotImplementedError):
+            self.path(path).owner()
+        with self.assertRaises(NotImplementedError):
+            self.path(path).group()
+
 
 class RealPathlibUsageInOsFunctionsTest(FakePathlibUsageInOsFunctionsTest):
     def use_real_fs(self):


### PR DESCRIPTION
- return the current user/group name under Posix
- raises NotImplementedError under Windows
- fixes #629