### PR TITLE
Fixed handling of alternative path separator in some functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ The released versions correspond to PyPi releases.
 
 ## Version 4.6.0 (as yet unreleased)
 
+### Fixes
+* fixed handling of alternative path separator in `os.path.split`, 
+  `os.path.splitdrive` and `glob.glob`
+  (see [#632](../../issues/632))
+  
 ## [Version 4.5.1](https://pypi.python.org/pypi/pyfakefs/4.5.1) (2021-08-29)
 This is a bugfix release.
 

--- a/pyfakefs/tests/example.py
+++ b/pyfakefs/tests/example.py
@@ -121,7 +121,7 @@ def get_glob(glob_path):
     >>> import sys
     >>> if sys.platform.startswith('win'):
     ...     # Windows style path
-    ...     file_names == [r'\test\file1.txt', r'\test\file2.txt']
+    ...     file_names == [r'/test\file1.txt', r'/test\file2.txt']
     ... else:
     ...     # UNIX style path
     ...     file_names == ['/test/file1.txt', '/test/file2.txt']

--- a/pyfakefs/tests/example_test.py
+++ b/pyfakefs/tests/example_test.py
@@ -113,7 +113,7 @@ class TestExample(fake_filesystem_unittest.TestCase):  # pylint: disable=R0904
         matching_paths = sorted(example.get_glob('/test/dir1/dir*'))
         if is_windows:
             self.assertEqual(matching_paths,
-                             [r'\test\dir1\dir2a', r'\test\dir1\dir2b'])
+                             [r'/test/dir1\dir2a', r'/test/dir1\dir2b'])
         else:
             self.assertEqual(matching_paths,
                              ['/test/dir1/dir2a', '/test/dir1/dir2b'])

--- a/pyfakefs/tests/fake_filesystem_glob_test.py
+++ b/pyfakefs/tests/fake_filesystem_glob_test.py
@@ -35,7 +35,7 @@ class FakeGlobUnitTest(fake_filesystem_unittest.TestCase):
         self.assertEqual(glob.glob(''), [])
 
     def test_glob_star(self):
-        basedir = os.sep + 'xyzzy'
+        basedir = '/xyzzy'
         self.assertEqual([os.path.join(basedir, 'subdir'),
                           os.path.join(basedir, 'subdir2'),
                           os.path.join(basedir, 'subfile')],
@@ -46,7 +46,7 @@ class FakeGlobUnitTest(fake_filesystem_unittest.TestCase):
         self.assertEqual(['/xyzzy/subfile'], glob.glob('/xyzzy/subfile'))
 
     def test_glob_question(self):
-        basedir = os.sep + 'xyzzy'
+        basedir = '/xyzzy'
         self.assertEqual([os.path.join(basedir, 'subdir'),
                           os.path.join(basedir, 'subdir2'),
                           os.path.join(basedir, 'subfile')],
@@ -60,7 +60,7 @@ class FakeGlobUnitTest(fake_filesystem_unittest.TestCase):
         self.assertEqual([], glob.glob('nonexistent'))
 
     def test_magic_dir(self):
-        self.assertEqual([os.sep + '[Temp]'], glob.glob('/*emp*'))
+        self.assertEqual(['/[Temp]'], glob.glob('/*emp*'))
 
     def test_glob1(self):
         self.assertEqual(['[Temp]'], glob.glob1('/', '*Tem*'))

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -97,8 +97,8 @@ class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
         self.assertTrue(self.fs.exists('/fake_file.txt'))
         with open('/fake_file.txt') as f:
             content = f.read()
-        self.assertEqual(content, 'This test file was created using the '
-                                  'open() function.\n')
+        self.assertEqual('This test file was created using the '
+                         'open() function.\n', content)
 
     def test_io_open(self):
         """Fake io module is bound"""
@@ -109,8 +109,8 @@ class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
         self.assertTrue(self.fs.exists('/fake_file.txt'))
         with open('/fake_file.txt') as f:
             content = f.read()
-        self.assertEqual(content, 'This test file was created using the '
-                                  'io.open() function.\n')
+        self.assertEqual('This test file was created using the '
+                         'io.open() function.\n', content)
 
     def test_os(self):
         """Fake os module is bound"""
@@ -121,22 +121,21 @@ class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
     def test_glob(self):
         """Fake glob module is bound"""
         is_windows = sys.platform.startswith('win')
-        self.assertEqual(glob.glob('/test/dir1/dir*'),
-                         [])
+        self.assertEqual([], glob.glob('/test/dir1/dir*'))
         self.fs.create_dir('/test/dir1/dir2a')
         matching_paths = glob.glob('/test/dir1/dir*')
         if is_windows:
-            self.assertEqual(matching_paths, [r'\test\dir1\dir2a'])
+            self.assertEqual([r'/test/dir1\dir2a'], matching_paths)
         else:
-            self.assertEqual(matching_paths, ['/test/dir1/dir2a'])
+            self.assertEqual(['/test/dir1/dir2a'], matching_paths)
         self.fs.create_dir('/test/dir1/dir2b')
         matching_paths = sorted(glob.glob('/test/dir1/dir*'))
         if is_windows:
-            self.assertEqual(matching_paths,
-                             [r'\test\dir1\dir2a', r'\test\dir1\dir2b'])
+            self.assertEqual([r'/test/dir1\dir2a', r'/test/dir1\dir2b'],
+                             matching_paths)
         else:
-            self.assertEqual(matching_paths,
-                             ['/test/dir1/dir2a', '/test/dir1/dir2b'])
+            self.assertEqual(['/test/dir1/dir2a', '/test/dir1/dir2b'],
+                             matching_paths)
 
     def test_shutil(self):
         """Fake shutil module is bound"""


### PR DESCRIPTION
- affects os.path.split, os.path.splitdrive and glob.glob
- fixes #632