### PR TITLE
Do not set size to 0 on setting initial content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The released versions correspond to PyPi releases.
 ### Fixes
 * correctly handle file system space for files opened in write mode
   (see [#660](../../issues/660))
+* correctly handle reading/writing pipes via file
+  (see [#661](../../issues/661)) 
 
 ## [Version 4.5.4](https://pypi.python.org/pypi/pyfakefs/4.5.4) (2022-01-12)
 Minor bugfix release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # pyfakefs Release Notes
 The released versions correspond to PyPi releases.
 
+## Unreleased
+
+### Fixes
+* correctly handle file system space for files opened in write mode
+  (see [#660](../../issues/660))
+
 ## [Version 4.5.4](https://pypi.python.org/pypi/pyfakefs/4.5.4) (2022-01-12)
 Minor bugfix release.
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -439,8 +439,6 @@ class FakeFile:
         current_size = self.st_size or 0
         self.filesystem.change_disk_usage(
             st_size - current_size, self.name, self.st_dev)
-        if self._byte_contents:
-            self.size = 0
         self._byte_contents = byte_contents
         self.st_size = st_size
         self.epoch += 1

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -2750,7 +2750,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
             with self.open(write_fd, 'wb') as f:
                 self.assertEqual(4, f.write(b'test'))
             with self.open(read_fd, 'rb') as f:
-                self.assertEqual(b'test', f.read(4))
+                self.assertEqual(b'test', f.read())
         for fd in fds:
             self.os.close(fd)
 

--- a/pyfakefs/tests/test_utils.py
+++ b/pyfakefs/tests/test_utils.py
@@ -21,6 +21,7 @@ import stat
 import sys
 import tempfile
 import unittest
+from contextlib import contextmanager
 from unittest import mock
 
 from pyfakefs import fake_filesystem
@@ -68,6 +69,17 @@ class TestCase(unittest.TestCase):
 
     def assert_mode_equal(self, expected, actual):
         return self.assertEqual(stat.S_IMODE(expected), stat.S_IMODE(actual))
+
+    @contextmanager
+    def raises_os_error(self, subtype):
+        try:
+            yield
+            self.fail('No exception was raised, OSError expected')
+        except OSError as exc:
+            if isinstance(subtype, list):
+                self.assertIn(exc.errno, subtype)
+            else:
+                self.assertEqual(subtype, exc.errno)
 
     def assert_raises_os_error(self, subtype, expression, *args, **kwargs):
         """Asserts that a specific subtype of OSError is raised."""


### PR DESCRIPTION
- caused file system file to be wrong for non-empty files
- tests: add contextmanager version of assert_raises_os_error
- fixes #660

Correctly handle reading/writing pipes via file

- make numBytes argument optional
- open real pipe as file and store it if needed
- fixes #661