### PR TITLE
Use RealPathlibModule for all skipped modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ The released versions correspond to PyPi releases.
   (see [#661](../../issues/661))
 * disallow `encoding` argument on binary `open()`
   (see [#664](../../issues/664))
+* fixed compatibility issue with pytest 7.0.0
+  (see [#666](../../issues/666))
 
 ## [Version 4.5.4](https://pypi.python.org/pypi/pyfakefs/4.5.4) (2022-01-12)
 Minor bugfix release.

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -845,6 +845,12 @@ class RealPathlibPathModule:
     """Patches `pathlib.Path` by passing all calls to RealPathlibModule."""
     real_pathlib = None
 
+    @classmethod
+    def __instancecheck__(cls, instance):
+        # as we cannot derive from pathlib.Path, we fake
+        # the inheritance to pass isinstance checks - see #666
+        return isinstance(instance, PurePath)
+
     def __init__(self):
         if self.real_pathlib is None:
             self.__class__.real_pathlib = RealPathlibModule()

--- a/pyfakefs/pytest_plugin.py
+++ b/pyfakefs/pytest_plugin.py
@@ -8,7 +8,7 @@ def my_fakefs_test(fs):
     fs.create_file('/var/data/xx1.txt')
     assert os.path.exists('/var/data/xx1.txt')
 """
-
+import _pytest
 import py
 import pytest
 
@@ -16,6 +16,7 @@ from pyfakefs.fake_filesystem_unittest import Patcher
 
 Patcher.SKIPMODULES.add(py)
 Patcher.SKIPMODULES.add(pytest)
+Patcher.SKIPMODULES.add(_pytest.pathlib)
 
 
 @pytest.fixture

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -1814,6 +1814,8 @@ class DiskSpaceTest(TestCase):
                 f.write('b' * 110)
                 with self.raises_os_error(errno.ENOSPC):
                     f.flush()
+        with self.open('bar.txt') as f:
+            self.assertEqual('', f.read())
 
     def test_disk_full_append(self):
         file_path = 'bar.txt'
@@ -1826,6 +1828,8 @@ class DiskSpaceTest(TestCase):
                 f.write('b' * 41)
                 with self.raises_os_error(errno.ENOSPC):
                     f.flush()
+        with self.open('bar.txt') as f:
+            self.assertEqual(f.read(), 'a' * 60)
 
     def test_disk_full_after_reopened_rplus_seek(self):
         with self.open('bar.txt', 'w') as f:
@@ -1838,6 +1842,8 @@ class DiskSpaceTest(TestCase):
                 f.write('b' * 60)
                 with self.raises_os_error(errno.ENOSPC):
                     f.flush()
+        with self.open('bar.txt') as f:
+            self.assertEqual(f.read(), 'a' * 60)
 
 
 class MountPointTest(TestCase):


### PR DESCRIPTION
- avoids the use of FakePathLibPath in pathlib
- add _pytest.pathlib to skipped modules,
  fake isinstance check for RealPathlibPathModule
- prevents issue with _pytest.pathlib in pytest 7.0.0,
  which would cause all tests with fs fixture to fail
- see #666