### PR TITLE
add Python 3.9 and 3.10 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py35,py36,py37,py38,py39,py310,pypy
+envlist=py36,py37,py38,py39,py310,pypy3
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py35,py36,py37,py38,pypy
+envlist=py35,py36,py37,py38,py39,py310,pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
Tested changes with `tox -e py39,py310' and tests pass.