### PR TITLE
PyTest -> pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ using convenience functions.
 pyfakefs works with CPython 3.6 and above, on Linux, Windows and OSX 
 (MacOS), and with PyPy3.
 
-pyfakefs works with [PyTest](http://doc.pytest.org) version 3.0.0 or above.
+pyfakefs works with [pytest](http://doc.pytest.org) version 3.0.0 or above.
 
 pyfakefs will not work with Python libraries that use C libraries to access the
 file system.  This is because pyfakefs cannot patch the underlying C libraries'

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -9,7 +9,7 @@ The software under test requires no modification to work with pyfakefs.
 pyfakefs works with CPython 3.6 and above, on Linux, Windows and OSX
 (MacOS), and with PyPy3.
 
-pyfakefs works with `PyTest <doc.pytest.org>`__ version 3.0.0 or above.
+pyfakefs works with `pytest <doc.pytest.org>`__ version 3.0.0 or above.
 
 Installation
 ------------


### PR DESCRIPTION
`README.md` and `intro.rst` both had a reference to pytest as "PyTest".  
pytest.org only refers to pytest in all lowercase, and the core team prefers that spelling. 

Also, thanks for including a pytest fixture in pyfakefs. Super cool.