### PR TITLE
Change handling of root dir under Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ The released versions correspond to PyPi releases.
 
 ## Unreleased
 
+### Changes
+* under Windows, the root path is now effectively `C:\` instead of `\`; a 
+  path starting with `\` points to the current drive as in the real file 
+  system (see [#673](../../issues/673))
+
 ## [Version 4.5.6](https://pypi.python.org/pypi/pyfakefs/4.5.6) (2022-03-17)
 Fixes a regression which broke tests with older pytest versions (< 3.9).
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -641,7 +641,8 @@ class FakePath(pathlib.Path):
                 home = os.path.join('C:', 'Users', username)
             else:
                 home = os.path.join('home', username)
-            cls.filesystem.create_dir(home)
+            if not cls.filesystem.exists(home):
+                cls.filesystem.create_dir(home)
         return cls(home.replace(os.sep, cls.filesystem.path_separator))
 
     def samefile(self, other_path):

--- a/pyfakefs/tests/fake_filesystem_vs_real_test.py
+++ b/pyfakefs/tests/fake_filesystem_vs_real_test.py
@@ -43,7 +43,7 @@ def _get_errno(raised_error):
 
 class TestCase(unittest.TestCase):
     is_windows = sys.platform.startswith('win')
-    _FAKE_FS_BASE = sep('/fakefs')
+    _FAKE_FS_BASE = 'C:\\fakefs' if is_windows else '/fakefs'
 
 
 class FakeFilesystemVsRealTest(TestCase):

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -106,9 +106,9 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.skip_real_fs()
         dirname = self.make_path('foo', 'bar')
         self.create_dir(dirname)
-        self.assertEqual(self.os.getcwd(), self.os.path.sep)
+        self.assertEqual(self.filesystem.root_dir_name, self.os.getcwd())
         self.os.chdir(dirname)
-        self.assertEqual(self.os.getcwd(), dirname)
+        self.assertEqual(dirname, self.os.getcwd())
 
     def test_listdir(self):
         self.assert_raises_os_error(

--- a/pyfakefs/tests/fake_tempfile_test.py
+++ b/pyfakefs/tests/fake_tempfile_test.py
@@ -77,7 +77,7 @@ class FakeTempfileModuleTest(fake_filesystem_unittest.TestCase):
         self.assertEqual(2, len(temporary))
         self.assertEqual(next_fd, temporary[0])
         self.assertTrue(temporary[1].startswith(
-            os.path.join(os.sep, 'dir', 'tmp')))
+            os.path.join(self.fs.root_dir_name, 'dir', 'tmp')))
         self.assertTrue(self.fs.exists(temporary[1]))
         mode = 0o666 if self.fs.is_windows_fs else 0o600
         self.assertEqual(self.fs.get_object(temporary[1]).st_mode,


### PR DESCRIPTION
- as Windows has no root dir as such, we use the
  current drive as root dir to better emulate the fs
- as in the real fs, if a path starts with a path separator,
  it points to the current drive (e.g. the root of cwd)
- fixes #673