### PR TITLE
Add some support for Python 3.11

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt -r extra_requirements.txt
-          python -m pip install mypy==0.812
+          python -m pip install mypy==0.950
       - name: Run typing checks
         run: python -m mypy .
 
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11-dev"]
         include:
           - python-version: pypy3
             os: ubuntu-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,13 @@ The released versions correspond to PyPi releases.
 
 ## Unreleased
 
-
 ### Changes
 * Python 3.6 has reached its end of life on 2021/12/23 and is no
   longer officially supported by pyfakefs
   ** `os.stat_float_times` has been removed in Python 3.7 and is therefore no 
      longer supported
+* added some support for the upcoming Python version 3.11
+  (see [#677](../../issues/677))
 * under Windows, the root path is now effectively `C:\` instead of `\`; a 
   path starting with `\` points to the current drive as in the real file 
   system (see [#673](../../issues/673))

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For example, pyfakefs will not work with [`lxml`](http://lxml.de/).  In this cas
 ### Continuous integration
 
 pyfakefs is currently automatically tested on Linux, MacOS and Windows, with
-Python 3.7 to 3.10, and with PyPy3 on Linux, using
+Python 3.7 to 3.11, and with PyPy3 on Linux, using
 [GitHub Actions](https://github.com/jmcgeheeiv/pyfakefs/actions).
 
 ### Running pyfakefs unit tests

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -31,16 +31,20 @@ get the properties of the underlying fake filesystem.
 import errno
 import fnmatch
 import functools
+import inspect
 import os
 import pathlib
-from pathlib import PurePath
 import re
 import sys
+from pathlib import PurePath
+from typing import Callable
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
 
 from pyfakefs import fake_scandir
 from pyfakefs.extra_packages import use_scandir
-from pyfakefs.fake_filesystem import FakeFileOpen, FakeFilesystem
+from pyfakefs.fake_filesystem import (
+    FakeFileOpen, FakeFilesystem, use_original_os
+)
 
 
 def init_module(filesystem):
@@ -98,27 +102,26 @@ class _FakeAccessor(accessor):  # type: ignore [valid-type, misc]
     if use_scandir:
         scandir = _wrap_strfunc(fake_scandir.scandir)
 
-    chmod = _wrap_strfunc(FakeFilesystem.chmod)
-
     if hasattr(os, "lchmod"):
         lchmod = _wrap_strfunc(lambda fs, path, mode: FakeFilesystem.chmod(
             fs, path, mode, follow_symlinks=False))
     else:
-        def lchmod(self, pathobj,  *args, **kwargs):
+        def lchmod(self, pathobj, *args, **kwargs):
             """Raises not implemented for Windows systems."""
             raise NotImplementedError("lchmod() not available on this system")
 
-        def chmod(self, pathobj, *args, **kwargs):
-            if "follow_symlinks" in kwargs:
-                if sys.version_info < (3, 10):
-                    raise TypeError("chmod() got an unexpected keyword "
-                                    "argument 'follow_synlinks'")
-                if (not kwargs["follow_symlinks"] and
-                        os.chmod not in os.supports_follow_symlinks):
-                    raise NotImplementedError(
-                        "`follow_symlinks` for chmod() is not available "
-                        "on this system")
-            return pathobj.filesystem.chmod(str(pathobj), *args, **kwargs)
+    def chmod(self, pathobj, *args, **kwargs):
+        if "follow_symlinks" in kwargs:
+            if sys.version_info < (3, 10):
+                raise TypeError("chmod() got an unexpected keyword "
+                                "argument 'follow_symlinks'")
+
+            if (not kwargs["follow_symlinks"] and
+                    os.os_module.chmod not in os.supports_follow_symlinks):
+                raise NotImplementedError(
+                    "`follow_symlinks` for chmod() is not available "
+                    "on this system")
+        return pathobj.filesystem.chmod(str(pathobj), *args, **kwargs)
 
     mkdir = _wrap_strfunc(FakeFilesystem.makedir)
 
@@ -793,6 +796,8 @@ class RealPath(pathlib.Path):
     Needed because `Path` in `pathlib` is always faked, even if `pathlib`
     itself is not.
     """
+    _flavour = (pathlib._WindowsFlavour() if os.name == 'nt'  # type:ignore
+                else pathlib._PosixFlavour())  # type:ignore
 
     def __new__(cls, *args, **kwargs):
         """Creates the correct subclass based on OS."""
@@ -803,6 +808,41 @@ class RealPath(pathlib.Path):
         return self
 
 
+if sys.version_info > (3, 10):
+    def with_original_os(f: Callable) -> Callable:
+        """Decorator used for real pathlib Path methods to ensure that
+        real os functions instead of faked ones are used."""
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            with use_original_os():
+                return f(*args, **kwargs)
+        return wrapped
+
+    for name, fn in inspect.getmembers(RealPath, inspect.isfunction):
+        setattr(RealPath, name, with_original_os(fn))
+
+
+class RealPathlibPathModule:
+    """Patches `pathlib.Path` by passing all calls to RealPathlibModule."""
+    real_pathlib = None
+
+    @classmethod
+    def __instancecheck__(cls, instance):
+        # as we cannot derive from pathlib.Path, we fake
+        # the inheritance to pass isinstance checks - see #666
+        return isinstance(instance, PurePath)
+
+    def __init__(self):
+        if self.real_pathlib is None:
+            self.__class__.real_pathlib = RealPathlibModule()
+
+    def __call__(self, *args, **kwargs):
+        return RealPath(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self.real_pathlib.Path, name)
+
+
 class RealPathlibModule:
     """Used to replace `pathlib` for skipped modules.
     As the original `pathlib` is always patched to use the fake path,
@@ -810,8 +850,6 @@ class RealPathlibModule:
     """
 
     def __init__(self):
-        RealPathlibModule.PureWindowsPath._flavour = pathlib._WindowsFlavour()
-        RealPathlibModule.PurePosixPath._flavour = pathlib._PosixFlavour()
         self._pathlib_module = pathlib
 
     class PurePosixPath(PurePath):
@@ -840,24 +878,3 @@ class RealPathlibModule:
     def __getattr__(self, name):
         """Forwards any unfaked calls to the standard pathlib module."""
         return getattr(self._pathlib_module, name)
-
-
-class RealPathlibPathModule:
-    """Patches `pathlib.Path` by passing all calls to RealPathlibModule."""
-    real_pathlib = None
-
-    @classmethod
-    def __instancecheck__(cls, instance):
-        # as we cannot derive from pathlib.Path, we fake
-        # the inheritance to pass isinstance checks - see #666
-        return isinstance(instance, PurePath)
-
-    def __init__(self):
-        if self.real_pathlib is None:
-            self.__class__.real_pathlib = RealPathlibModule()
-
-    def __call__(self, *args, **kwargs):
-        return self.real_pathlib.Path(*args, **kwargs)
-
-    def __getattr__(self, name):
-        return getattr(self.real_pathlib.Path, name)

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -221,13 +221,13 @@ class FakeStatResult:
         mode = 0
         st_mode = self.st_mode
         if st_mode & stat.S_IFDIR:
-            mode |= stat.FILE_ATTRIBUTE_DIRECTORY
+            mode |= stat.FILE_ATTRIBUTE_DIRECTORY  # type:ignore[attr-defined]
         if st_mode & stat.S_IFREG:
-            mode |= stat.FILE_ATTRIBUTE_NORMAL
+            mode |= stat.FILE_ATTRIBUTE_NORMAL  # type:ignore[attr-defined]
         if st_mode & (stat.S_IFCHR | stat.S_IFBLK):
-            mode |= stat.FILE_ATTRIBUTE_DEVICE
+            mode |= stat.FILE_ATTRIBUTE_DEVICE  # type:ignore[attr-defined]
         if st_mode & stat.S_IFLNK:
-            mode |= stat.FILE_ATTRIBUTE_REPARSE_POINT
+            mode |= stat.FILE_ATTRIBUTE_REPARSE_POINT  # type:ignore
         return mode
 
     @property

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -1486,6 +1486,7 @@ class FakeFileOpenLineEndingTest(FakeFileOpenTestBase):
         with self.open(file_path, mode='r', newline='\r\n') as f:
             self.assertEqual(['1\r\n', '2\n3\r4'], f.readlines())
 
+    @unittest.skipIf(sys.version_info >= (3, 10), "U flag no longer supported")
     def test_read_with_ignored_universal_newlines_flag(self):
         file_path = self.make_path('some_file')
         file_contents = b'1\r\n2\n3\r4'
@@ -1496,6 +1497,14 @@ class FakeFileOpenLineEndingTest(FakeFileOpenTestBase):
             self.assertEqual('1\r\n2\n3\r4', f.read())
         with self.open(file_path, mode='U', newline='\r') as f:
             self.assertEqual('1\r\n2\n3\r4', f.read())
+
+    @unittest.skipIf(sys.version_info < (3, 11), "U flag still supported")
+    def test_universal_newlines_flag_not_supported(self):
+        file_path = self.make_path('some_file')
+        file_contents = b'1\r\n2\n3\r4'
+        self.create_file(file_path, contents=file_contents)
+        with self.assertRaises(ValueError):
+            self.open(file_path, mode='U', newline='\r')
 
     def test_write_with_newline_arg(self):
         file_path = self.make_path('some_file')

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -27,26 +27,36 @@ import stat
 import sys
 import unittest
 
+from pyfakefs import fake_pathlib, fake_filesystem, fake_filesystem_unittest
 from pyfakefs.fake_filesystem import is_root
-
-from pyfakefs import fake_pathlib, fake_filesystem
 from pyfakefs.helpers import IS_PYPY
-from pyfakefs.tests.test_utils import RealFsTestCase
+from pyfakefs.tests.test_utils import RealFsTestMixin
 
 is_windows = sys.platform == 'win32'
 
 
-class RealPathlibTestCase(RealFsTestCase):
+class RealPathlibTestCase(fake_filesystem_unittest.TestCase, RealFsTestMixin):
+    is_windows = sys.platform == 'win32'
+
     def __init__(self, methodName='runTest'):
-        super(RealPathlibTestCase, self).__init__(methodName)
-        self.pathlib = pathlib
-        self.path = None
+        fake_filesystem_unittest.TestCase.__init__(self, methodName)
+        RealFsTestMixin.__init__(self)
 
     def setUp(self):
-        super().setUp()
+        RealFsTestMixin.setUp(self)
+        self.filesystem = None
+        self.real_os = os
         if not self.use_real_fs():
-            self.pathlib = fake_pathlib.FakePathlibModule(self.filesystem)
-        self.path = self.pathlib.Path
+            self.setUpPyfakefs()
+            self.filesystem = self.fs
+            self.create_basepath()
+        self.pathlib = pathlib
+        self.path = pathlib.Path
+        self.os = os
+        self.open = open
+
+    def use_real_fs(self):
+        return False
 
 
 class FakePathlibInitializationTest(RealPathlibTestCase):
@@ -178,7 +188,8 @@ class FakePathlibInitializationWithDriveTest(RealPathlibTestCase):
 
 
 class RealPathlibInitializationWithDriveTest(
-        FakePathlibInitializationWithDriveTest):
+    FakePathlibInitializationWithDriveTest
+):
     def use_real_fs(self):
         return True
 
@@ -383,7 +394,7 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
         self.skip_if_symlink_not_supported()
         file_stat = self.os.stat(self.file_path)
         link_stat = self.os.lstat(self.file_link_path)
-        if not hasattr(os, "lchmod"):
+        if not hasattr(self.real_os, "lchmod"):
             with self.assertRaises(NotImplementedError):
                 self.path(self.file_link_path).lchmod(0o444)
         else:
@@ -393,13 +404,16 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
             self.assertEqual(link_stat.st_mode & 0o777700,
                              stat.S_IFLNK | 0o700)
 
-    @unittest.skipIf(sys.version_info < (3, 10),
-                     "follow_symlinks argument new in Python 3.10")
+    @unittest.skipIf(
+        sys.version_info < (3, 10),
+        "follow_symlinks argument new in Python 3.10"
+    )
     def test_chmod_no_followsymlinks(self):
         self.skip_if_symlink_not_supported()
         file_stat = self.os.stat(self.file_path)
         link_stat = self.os.lstat(self.file_link_path)
-        if os.chmod not in os.supports_follow_symlinks or IS_PYPY:
+        if (self.real_os.chmod not in os.supports_follow_symlinks
+                or IS_PYPY):
             with self.assertRaises(NotImplementedError):
                 self.path(self.file_link_path).chmod(0o444,
                                                      follow_symlinks=False)
@@ -443,11 +457,11 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
         file_path = self.os.path.join(dir_path, 'some_file')
         self.create_file(file_path)
         self.os.chmod(dir_path, 0o000)
-        iter = self.path(dir_path).iterdir()
+        it = self.path(dir_path).iterdir()
         if not is_root():
-            self.assert_raises_os_error(errno.EACCES, list, iter)
+            self.assert_raises_os_error(errno.EACCES, list, it)
         else:
-            path = str(list(iter)[0])
+            path = str(list(it)[0])
             self.assertTrue(path.endswith('some_file'))
 
     def test_resolve_nonexisting_file(self):

--- a/pyfakefs/tests/test_utils.py
+++ b/pyfakefs/tests/test_utils.py
@@ -81,17 +81,6 @@ class TestCase(unittest.TestCase):
             else:
                 self.assertEqual(subtype, exc.errno)
 
-    def assert_raises_os_error(self, subtype, expression, *args, **kwargs):
-        """Asserts that a specific subtype of OSError is raised."""
-        try:
-            expression(*args, **kwargs)
-            self.fail('No exception was raised, OSError expected')
-        except OSError as exc:
-            if isinstance(subtype, list):
-                self.assertIn(exc.errno, subtype)
-            else:
-                self.assertEqual(subtype, exc.errno)
-
 
 class RealFsTestMixin:
     """Test mixin to allow tests to run both in the fake filesystem and in the
@@ -148,6 +137,9 @@ class RealFsTestMixin:
     def use_real_fs(self):
         """Return True if the real file system shall be tested."""
         return False
+
+    def setUpFileSystem(self):
+        pass
 
     def path_separator(self):
         """Can be overwritten to use a specific separator in the
@@ -362,7 +354,7 @@ class RealFsTestMixin:
         if self.filesystem is not None:
             old_base_path = self.base_path
             self.base_path = self.filesystem.path_separator + 'basepath'
-            if self.is_windows_fs:
+            if self.filesystem.is_windows_fs:
                 self.base_path = 'C:' + self.base_path
             if old_base_path != self.base_path:
                 if old_base_path is not None:
@@ -402,6 +394,17 @@ class RealFsTestMixin:
                               DummyTime(start, step))
         return DummyMock()
 
+    def assert_raises_os_error(self, subtype, expression, *args, **kwargs):
+        """Asserts that a specific subtype of OSError is raised."""
+        try:
+            expression(*args, **kwargs)
+            self.fail('No exception was raised, OSError expected')
+        except OSError as exc:
+            if isinstance(subtype, list):
+                self.assertIn(exc.errno, subtype)
+            else:
+                self.assertEqual(subtype, exc.errno)
+
 
 class RealFsTestCase(TestCase, RealFsTestMixin):
     """Can be used as base class for tests also running in the real
@@ -425,9 +428,6 @@ class RealFsTestCase(TestCase, RealFsTestMixin):
 
     def tearDown(self):
         RealFsTestMixin.tearDown(self)
-
-    def setUpFileSystem(self):
-        pass
 
     @property
     def is_windows_fs(self):

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Operating System :: POSIX',


### PR DESCRIPTION
- add Python 3.11 to CI tests
- adapt the pathlib tests to work with Python 3.11
- adapt handling of pathlib in unfaked modules:
  need to ensure that the original os module is used,
  as pathlib has removed the accessor layer and now
  directly accesses os
- add target_is_directory argument to symlink (ignored)
- 'U' open mode is no longer allowed in Python 3.11
- closes #677