### PR TITLE
Change pathlib.Path.owner()/group() to behave like real os

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,12 +8,16 @@ The released versions correspond to PyPi releases.
   longer officially supported by pyfakefs
   ** `os.stat_float_times` has been removed in Python 3.7 and is therefore no 
      longer supported
-* added some support for the upcoming Python version 3.11
-  (see [#677](../../issues/677))
 * under Windows, the root path is now effectively `C:\` instead of `\`; a 
   path starting with `\` points to the current drive as in the real file 
   system (see [#673](../../issues/673))
+* fake `pathlib.Path.owner()` and `pathlib.Path.group()` now behave like the 
+  real methods - they look up the real user/group name for the user/group id
+  that is associated with the fake file (see [#678](../../issues/678))
 
+### New Features
+* added some support for the upcoming Python version 3.11
+  (see [#677](../../issues/677))
 
 ## [Version 4.5.6](https://pypi.python.org/pypi/pyfakefs/4.5.6) (2022-03-17)
 Fixes a regression which broke tests with older pytest versions (< 3.9).

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -754,20 +754,22 @@ class FakePathlibModule:
         __slots__ = ()
 
         def owner(self):
-            """Return the current user name. It is assumed that the fake
-            file system was created by the current user.
+            """Return the username of the file owner.
+             It is assumed that `st_uid` is related to a real user,
+             otherwise `KeyError` is raised.
             """
             import pwd
 
-            return pwd.getpwuid(os.getuid()).pw_name
+            return pwd.getpwuid(self.stat().st_uid).pw_name
 
         def group(self):
-            """Return the current group name. It is assumed that the fake
-            file system was created by the current user.
+            """Return the group name of the file group.
+            It is assumed that `st_gid` is related to a real group,
+            otherwise `KeyError` is raised.
             """
             import grp
 
-            return grp.getgrgid(os.getgid()).gr_name
+            return grp.getgrgid(self.stat().st_gid).gr_name
 
     Path = FakePath
 


### PR DESCRIPTION
- both methods now look up the real user/group name for the user/group id
  that is associated with the fake file
- assumes a valid user and group id is set
- closes #678