### PR TITLE
Add support for opener in open()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ The released versions correspond to PyPi releases.
 
 ## Unreleased
 
+### Fixes
+* added support for `opener` argument in `open`, which is used in `tempfile`
+  in Python 3.11 since beta 4 (see [#686](../../issues/686))
+
 ## [Version 4.6.0](https://pypi.python.org/pypi/pyfakefs/4.6.0) (2022-07-12)
 Adds support for Python 3.11, removes support for Python 3.6, changes root 
 path behavior under Windows. 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -5719,7 +5719,9 @@ class FakeFileOpen:
             closefd: If a file descriptor rather than file name is passed,
                 and this is set to `False`, then the file descriptor is kept
                 open when file is closed.
-            opener: not supported.
+            opener: an optional function object that will be called with
+                `file_` and the open flags (derived from `mode`) and returns
+                a file descriptor.
             open_modes: Modes for opening files if called from low-level API.
 
         Returns:
@@ -5740,6 +5742,11 @@ class FakeFileOpen:
             raise ValueError("binary mode doesn't take an encoding argument")
 
         newline, open_modes = self._handle_file_mode(mode, newline, open_modes)
+
+        if opener is not None:
+            # opener shall return a file descriptor, which will be handled
+            # here as if directly passed
+            file_ = opener(file_, open_modes)
 
         file_object, file_path, filedes, real_path = self._handle_file_arg(
             file_)


### PR DESCRIPTION
- needed to support tempfile in Python 3.11
- fixes #686