### PR TITLE
Do not use the build-in opener in pathlib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The released versions correspond to PyPi releases.
 ### Fixes
 * reverted a performance optimization introduced in version 3.3.0 that
   caused hanging tests with installed torch (see [#693](../../issues/693))
+* do not use the build-in opener in `pathlib` as it may cause problems
+  (see [#697](../../issues/697))
 
 ## [Version 4.6.3](https://pypi.python.org/pypi/pyfakefs/4.6.3) (2022-07-20)
 Another patch release that fixes a regression in version 4.6.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -5770,7 +5770,9 @@ class FakeFileOpen:
 
         newline, open_modes = self._handle_file_mode(mode, newline, open_modes)
 
-        if opener is not None:
+        # do not use the opener in pathlib, as it does nothing interesting
+        # but may not be patched under some circumstances (see #697)
+        if opener is not None and opener.__module__ != 'pathlib':
             # opener shall return a file descriptor, which will be handled
             # here as if directly passed
             file_ = opener(file_, self._open_flags_from_open_modes(open_modes))


### PR DESCRIPTION
- it may use a cached accessor instead of the fake one
- see #697 