### PR TITLE
Do not allow nested fixtures

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -135,8 +135,8 @@ jobs:
         shell: bash
       - name: Run pytest tests
         run: |
-          export PY_VERSION=${{ matrix.python-version }}
-          $GITHUB_WORKSPACE/.github/workflows/run_pytest.sh
+          echo "$(python -m pytest pyfakefs/pytest_tests/pytest_plugin_failing_helper.py)" > ./testresult.txt
+          python -m pytest pyfakefs/pytest_tests
         shell: bash
 
   dependency-check:

--- a/.github/workflows/run_pytest.sh
+++ b/.github/workflows/run_pytest.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-python -m pytest pyfakefs/pytest_tests/pytest_plugin_test.py
-if [[ $PY_VERSION == '3.6' ]] || [[ $PY_VERSION == '3.7' ]] || [[ $PY_VERSION == '3.8' ]] || [[ $PY_VERSION == '3.9' ]] ; then
-    python -m pytest pyfakefs/pytest_tests/pytest_fixture_test.py
-fi
-python -m pytest pyfakefs/pytest_tests/pytest_plugin_failing_helper.py > ./testresult.txt
-python -m pytest pyfakefs/pytest_tests/pytest_check_failed_plugin_test.py

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ The released versions correspond to PyPi releases.
 
 ## Unreleased
 
+### Changes
+* `fs` fixtures cannot be nested; any nested `fs` fixture (for example 
+  inside an `fs_session` or `fs_module` fixture) will just reference the outer
+  fixture (the behavior had been unexpected before)
+
 ### Fixes
 * reverted a performance optimization introduced in version 3.3.0 that
   caused hanging tests with installed torch (see [#693](../../issues/693))

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,9 +64,15 @@ tests:
         """
         yield fs
 
+Module- and session scoped fixtures
+...................................
 For convenience, module- and session-scoped fixtures with the same
 functionality are provided, named ``fs_module`` and ``fs_session``,
 respectively.
+
+.. caution:: If any of these fixtures is active, any other ``fs`` fixture will
+  not setup / tear down the fake filesystem in the current scope; instead, it
+  will just serve as a reference to the active fake filesystem.
 
 
 Patch using fake_filesystem_unittest.Patcher

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -5772,8 +5772,9 @@ class FakeFileOpen:
 
         newline, open_modes = self._handle_file_mode(mode, newline, open_modes)
 
-        # do not use the opener in pathlib, as it does nothing interesting
-        # but may not be patched under some circumstances (see #697)
+        # the pathlib opener is defined in a Path instance that may not be
+        # patched under some circumstances; as it just calls standard open(),
+        # we may ignore it, as it would not change the behavior
         if opener is not None and opener.__module__ != 'pathlib':
             # opener shall return a file descriptor, which will be handled
             # here as if directly passed

--- a/pyfakefs/pytest_tests/pytest_module_fixture_test.py
+++ b/pyfakefs/pytest_tests/pytest_module_fixture_test.py
@@ -1,0 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import pytest
+
+
+@pytest.fixture(scope='module', autouse=True)
+def use_fs(fs_module):
+    fs_module.create_file(os.path.join('foo', 'bar'))
+    yield fs_module
+
+
+def test_fs_uses_fs_module(fs):
+    # check that `fs` uses the same filesystem as `fs_module`
+    assert os.path.exists(os.path.join('foo', 'bar'))


### PR DESCRIPTION
- nested fixtures will reference the outer fixture

This is needed if using module or session scoped fixtures. The current behavior is inconsistent, as it would stop patching after the inner fixture is ended, and break the outer fixture.
If really needed, we may think about adding real nesting behavior, which would be more complicated to implement.