### PR TITLE
Do not skip filesystem modules by name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ The released versions correspond to PyPi releases.
   (see [#707](../../issues/707))
 * return the expected type from `fcntl.ioctl` and `fcntl.fcntl` calls if `arg`
   is of type `byte`; the call itself does nothing as before 
+* do not skip filesystem modules by name to allow using own modules with 
+  the same name (see [#707](../../issues/707))
 
 
 ## [Version 4.6.3](https://pypi.python.org/pypi/pyfakefs/4.6.3) (2022-07-20)

--- a/pyfakefs/pytest_tests/io.py
+++ b/pyfakefs/pytest_tests/io.py
@@ -1,0 +1,14 @@
+"""
+This is a test case for pyfakefs issue #708.
+It tests the usage of an own module with the same name as a patched filesystem
+module, the content is taken from the issue.
+"""
+
+
+class InputStream:
+    def __init__(self, name):
+        self.name = name
+
+    def read(self):
+        with open(self.name, 'r') as f:
+            return f.readline()

--- a/pyfakefs/pytest_tests/pytest_plugin_test.py
+++ b/pyfakefs/pytest_tests/pytest_plugin_test.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 from pyfakefs.fake_filesystem_unittest import Pause
+import pyfakefs.pytest_tests.io
 
 
 def test_fs_fixture(fs):
@@ -50,3 +51,12 @@ def test_pause_resume_contextmanager(fs):
         assert os.path.exists(real_temp_file.name)
     assert not os.path.exists(real_temp_file.name)
     assert os.path.exists(fake_temp_file.name)
+
+
+def test_use_own_io_module(fs):
+    filepath = 'foo.txt'
+    with open(filepath, 'w') as f:
+        f.write('bar')
+
+    stream = pyfakefs.pytest_tests.io.InputStream(filepath)
+    assert stream.read() == 'bar'


### PR DESCRIPTION
- allows using own modules with the same name
- fixes #708