### PR TITLE
Fix `fake_pathlib` typo

### DIFF
--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -21,7 +21,7 @@ Usage:
 
 * Stand-alone with FakeFilesystem:
   `filesystem = fake_filesystem.FakeFilesystem()`
-  `fake_pathlib_module = fake_filesystem.FakePathlibModule(filesystem)`
+  `fake_pathlib_module = fake_pathlib.FakePathlibModule(filesystem)`
   `path = fake_pathlib_module.Path('/foo/bar')`
 
 Note: as the implementation is based on FakeFilesystem, all faked classes
@@ -864,7 +864,7 @@ class FakePathlibModule:
 
     You need a fake_filesystem to use this:
     `filesystem = fake_filesystem.FakeFilesystem()`
-    `fake_pathlib_module = fake_filesystem.FakePathlibModule(filesystem)`
+    `fake_pathlib_module = fake_pathlib.FakePathlibModule(filesystem)`
     """
 
     def __init__(self, filesystem):


### PR DESCRIPTION
#### Describe the changes

Using the documentation as written without this change:
```python
>>> from pyfakefs import fake_filesystem
>>>
>>> filesystem = fake_filesystem.FakeFilesystem()
>>> fake_pathlib_module = fake_filesystem.FakePathlibModule(filesystem)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jfindlay/.local/share/venvs/shell/lib/python3.12/site-packages/pyfakefs/fake_filesystem.py", line 3249, in __getattr__
    raise AttributeError(f"No attribute {name!r}.")
AttributeError: No attribute 'FakePathlibModule'.. Did you mean: 'FakePathModule'?
```

#### Tasks
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
