### PR TITLE
Add support for `os.readinto` in Python 3.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,24 +13,27 @@ The released versions correspond to PyPI releases.
   the real filesystem behavior
 * remove support for Python versions before 3.10 (if needed, patches may be backported to the 5.x branch)
 
-### Unreleased
+## Unreleased
 
 ## Changes
 * the `errno` codes set in `OSError` have changed for some specific error conditions
   in Windows 11/Windows Server 2025; pyfakefs now matches this behavior
   instead of the previous behavior under Windows 10
 
-## Fixes
+### Enhancements
+* added support for `os.readinto` in Python 3.14
+
+### Fixes
 * fixes patching of Debian-specific `tempfile` in Python 3.13 (see [#1214](../../issues/1214))
 
 ## [Version 5.9.3](https://pypi.python.org/pypi/pyfakefs/5.9.3) (2025-08-28)
 Fixes a utility method.
 
-## Changes
+### Changes
 * a warning is now issued if trying to create a nested fake filesystem with custom arguments
   (custom arguments are ignored in this case, as the existing fake filesystem is used)
 
-## Fixes
+### Fixes
 * fixed `fake_filesystem.add_package_metadata` that had never worked correctly
   (see [#1205](../../issues/1205))
 

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -1406,6 +1406,16 @@ class FakeOsModule:
             raise NameError("name 'getgid' is not defined")
         return get_gid()
 
+    if sys.version_info >= (3, 14):
+
+        def readinto(self, fd, buffer):
+            """Read from a file descriptor fd into a mutable buffer object buffer."""
+            wrapper = self.filesystem.get_open_file(fd)
+            contents = wrapper.read(len(buffer))
+            count = len(contents)
+            buffer[:count] = contents
+            return count
+
     def fake_functions(self, original_functions) -> Set:
         functions = set()
         for fn in original_functions:

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -3076,6 +3076,25 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.assertEqual(fd1 + 1, fd3)
         self.assertEqual(fd1 + 3, fd4)
 
+    @unittest.skipIf(sys.version_info < (3, 14), "Introduced in Python 3.14")
+    def test_readinto(self):
+        file_path = self.make_path("foo", "bar.txt")
+        contents = b"Testing readinto"
+        self.create_file(file_path, contents=contents)
+        fd = self.os.open(file_path, os.O_RDONLY)
+        try:
+            buffer = bytearray(b"")
+            self.assertEqual(0, self.os.readinto(fd, buffer))
+            buffer = bytearray(b" " * 20)
+            self.assertEqual(len(contents), self.os.readinto(fd, buffer))
+            self.assertEqual(b"Testing readinto    ", buffer)
+            self.assertEqual(0, self.os.readinto(fd, buffer))
+            self.os.lseek(fd, 5, os.SEEK_SET)
+            self.assertEqual(len(contents) - 5, self.os.readinto(fd, buffer))
+            self.assertEqual(b"ng readintodinto    ", buffer)
+        finally:
+            self.os.close(fd)
+
 
 class RealOsModuleTest(FakeOsModuleTest):
     def use_real_fs(self):


### PR DESCRIPTION
#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
