### PR TITLE
Fix deadlock in shutil.copytree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ The released versions correspond to PyPI releases.
 * changed the default for `FakeFilesystem.shuffle_listdir_results` to `True` to reflect
   the real filesystem behavior
 
+### Fixes
+* fixed a deadlock in `shutil.copytree` if copying using an `shutil` function as
+  `copy_function` argument (see [#1235](../../issues/1235))
+
 ## [Version 5.10.0](https://pypi.python.org/pypi/pyfakefs/5.10.0) (2025-10-11)
 Adds official support for Python 3.14. Last minor version before the 6.0 release.
 

--- a/pyfakefs/tests/fake_filesystem_shutil_test.py
+++ b/pyfakefs/tests/fake_filesystem_shutil_test.py
@@ -212,6 +212,18 @@ class FakeShutilModuleTest(RealFsTestCase):
         self.assertTrue(os.path.exists(dst_file))
         self.assertEqual(os.stat(src_file).st_mode, os.stat(dst_file).st_mode)
 
+    def test_copytree_with_copy_function(self):
+        # regression test for #1235 (deadlock)
+        source_dir = Path(self.make_path("source_dir"))
+        target_dir = Path(self.make_path("target_dir"))
+        test_contents = "Test contents"
+        source_file = source_dir / "test.txt"
+        target_file = target_dir / "test.txt"
+        self.create_file(source_file, contents=test_contents)
+
+        shutil.copytree(source_dir, target_dir, copy_function=shutil.copy2)
+        assert target_file.read_text() == test_contents
+
     def test_permission_error_message(self):
         self.check_posix_only()
         dst_dir = Path(self.make_path("home1"))


### PR DESCRIPTION
- support recursive entry into patch functions
- happened if using shutil's own function as copy_function argument
- fixes #1235

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
