### PR TITLE
Fix pathlib.glob() for Python 3.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ The released versions correspond to PyPI releases.
 * changed the default for `FakeFilesystem.shuffle_listdir_results` to `True` to reflect
   the real filesystem behavior
 
+### Fixes
+* fixed `pathlib.glob()` for Python 3.14 (see [#1239](../../issues/1239))
+
 ## [Version 5.10.1](https://pypi.python.org/pypi/pyfakefs/5.10.1) (2025-10-27)
 Fixes a regression introduced in version 5.9.0.
 

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -1076,6 +1076,8 @@ class Patcher:
             globber.lstat = staticmethod(os.lstat)
             if sys.version_info < (3, 14):
                 globber.scandir = staticmethod(os.scandir)
+        if sys.version_info >= (3, 14):
+            globber.lexists = staticmethod(os.path.lexists)
 
     def patch_functions(self) -> None:
         assert self._stubs is not None

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -973,6 +973,13 @@ class FakePathlibPathFileOperationTest(RealPathlibTestCase):
             sorted(path.glob("*.py")),
         )
 
+    def test_glob_dir(self):
+        # regression test for #1239
+        root_dir = self.path(self.make_path("root"))
+        test_file = self.make_path(root_dir, "foo", "bar.txt")
+        self.create_file(test_file)
+        self.assertEqual([root_dir / "foo"], list(root_dir.glob("foo")))
+
     def test_glob_case_windows(self):
         self.check_windows_only()
         self.create_file(self.make_path("foo", "setup.py"))


### PR DESCRIPTION
- glob() defines another static method that has to be patched
- fixes #1239

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
