### PR TITLE
Workaround for strange type hint problem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ The released versions correspond to PyPI releases.
 * changed the default for `FakeFilesystem.shuffle_listdir_results` to `True` to reflect
   the real filesystem behavior
 
+### Fixes
+* fixes a problem with `Path` type hints using the pipe symbol in wrapped functions
+  inside an `fs` dependent fixture (see [#1242](../../issues/1242))
+
 ## [Version 5.10.2](https://pypi.python.org/pypi/pyfakefs/5.10.2) (2025-11-04)
 Fixes a problem with `pathlib.glob` in Python 3.14.
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -38,6 +38,7 @@ import warnings
 from pathlib import PurePath
 
 from collections.abc import Callable
+from typing import Any, Union
 from unittest import mock
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
 
@@ -1025,6 +1026,12 @@ class FakePathlibPathModule:
     def __init__(self, filesystem=None, from_patcher=False):
         if self.fake_pathlib is None:
             self.__class__.fake_pathlib = FakePathlibModule(filesystem, from_patcher)
+
+    def __or__(self, other: Any) -> Any:
+        # workaround for #1242 - pytest chokes on Path | ... type hint in wrapped function
+        return Union[self, other]
+
+    __ror__ = __or__
 
     @property
     def skip_names(self):

--- a/pyfakefs/pytest_tests/pytest_path_hint_test.py
+++ b/pyfakefs/pytest_tests/pytest_path_hint_test.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+
+# Regression test for #1242. Using a type hint in a wrapped function in a fixture dependent
+# on the 'fs' fixture that uses the union of 'Path' with another type using pipe symbol caused
+# "TypeError: unsupported operand type(s) for |: 'FakePathlibPathModule' and 'type'"
+
+
+@pytest.fixture
+def wrapper1(fs):
+    def wrapped(path: Path | str) -> Path | str:
+        return path
+
+    return wrapped
+
+
+@pytest.fixture
+def wrapper2(fs):
+    def wrapped(path: str | Path) -> Path | str:
+        return path
+
+    return wrapped
+
+
+def test_wrapped1(wrapper1):
+    assert wrapper1("test_folder") == "test_folder"
+
+
+def test_wrapped2(wrapper2):
+    assert wrapper2(Path("test_folder")) == Path("test_folder")


### PR DESCRIPTION
- fixes 'Path | str' like type hints in wrapped functions inside an `fs` dependent fixture
- see #1242

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
