### PR TITLE
Add coverage.python to skipped modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * fixes a problem with `Path` type hints using the pipe symbol in wrapped functions
   inside an `fs` dependent fixture (see [#1242](../../issues/1242))
+* fixes problem with new `coverage` in Python 3.14 using the fake filesystem
+  (see [#1245](../../issues/1245))
 
 ## [Version 5.10.2](https://pypi.python.org/pypi/pyfakefs/5.10.2) (2025-11-04)
 Fixes a problem with `pathlib.glob` in Python 3.14.

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -1012,7 +1012,12 @@ class Patcher:
         for name in self._fake_module_classes:
             self.fake_modules[name] = self._fake_module_classes[name](self.fs)
             if hasattr(self.fake_modules[name], "skip_names"):
-                self.fake_modules[name].skip_names = self.skip_names
+                self.fake_modules[name].skip_names = self.skip_names | {
+                    # also skip non-build-in skipped modules
+                    m.__name__
+                    for m in self.SKIPMODULES
+                    if m and "." in m.__name__
+                }
         self.fake_modules[PATH_MODULE] = self.fake_modules["os"].path
         for name in self._unfaked_module_classes:
             self.unfaked_modules[name] = self._unfaked_module_classes[name]()

--- a/pyfakefs/pytest_plugin.py
+++ b/pyfakefs/pytest_plugin.py
@@ -19,14 +19,21 @@ from pyfakefs.fake_filesystem_unittest import Patcher, Pause
 
 try:
     from _pytest import pathlib
+
+    Patcher.SKIPMODULES.add(pathlib)
 except ImportError:
-    pathlib = None  # type:ignore[assignment]
+    pass
+
+try:
+    from coverage import python  # type:ignore[import]
+
+    Patcher.SKIPMODULES.add(python)
+except ImportError:
+    pass
 
 Patcher.SKIPMODULES.add(py)
 Patcher.SKIPMODULES.add(pytest)
 Patcher.SKIPMODULES.add(capture)
-if pathlib is not None:
-    Patcher.SKIPMODULES.add(pathlib)
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ xdist = [
 
 [tool.setuptools]
 include-package-data = true
+py-modules = ["pyfakefs"]
 
 [tool.setuptools.package-data]
 where = ["pyfakefs"]


### PR DESCRIPTION
- consider skipped modules for fake `open`
- fixes #1245

This is working around the problem that file-system patching cannot be switched off for all other plugins.
Could not get a meaningful test together - only tested against the `hatch` repo where the problem occurred.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - n/a
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
