### PR TITLE
make old, deprecated "import py" optional

### DIFF
--- a/pyfakefs/pytest_plugin.py
+++ b/pyfakefs/pytest_plugin.py
@@ -32,6 +32,7 @@ except ImportError:
 
 try:
     import py
+
     Patcher.SKIPMODULES.add(py)
 except ImportError:
     pass


### PR DESCRIPTION
We'd like to remove `py` someday from Debian.

`pytest` has not relied on `py` for a long time