### PR TITLE
Replace backlink refs with weakrefs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The released versions correspond to PyPI releases.
 
 ### Changes
 * added more support for PyPy 3
+* _Caution:_ many back-link references have been replaced by weak references;
+  this may have unwanted consequences (crashes) for some untested workflows
 
 ### Infrastructure
 * added PyPy 3.11 to CI, added PyPy builds for all OSes
@@ -14,6 +16,8 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * fixed a problem with `readable` raising an error on a file object.
   (see [#1265](https://github.com/pytest-dev/pyfakefs/issues/1265))
+* avoid memory accumulation in consecutive tests by using weak references
+  (see [#1267](https://github.com/pytest-dev/pyfakefs/issues/1267))
 
 ## [Version 6.0.0](https://pypi.python.org/pypi/pyfakefs/6.0.0) (2025-12-21)
 Removes some deprecated functionality, removes support for Python < 3.10.

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -481,7 +481,7 @@ class TextBufferIO(io.TextIOWrapper):
 
 
 def is_called_from_skipped_module(
-    skip_names: list, case_sensitive: bool, check_open_code: bool = False
+    skip_names: list | set, case_sensitive: bool, check_open_code: bool = False
 ) -> bool:
     def starts_with(path, string):
         if case_sensitive:

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -209,8 +209,8 @@ class FakeDirectoryUnitTest(TestCase):
 
 class SetLargeFileSizeTest(TestCase):
     def setUp(self):
-        filesystem = fake_filesystem.FakeFilesystem()
-        self.fake_file = fake_filesystem.FakeFile("foobar", filesystem=filesystem)
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        self.fake_file = fake_filesystem.FakeFile("foobar", filesystem=self.filesystem)
 
     def test_should_throw_if_size_is_not_integer(self):
         with self.raises_os_error(errno.ENOSPC):


### PR DESCRIPTION
- includes links to filesystem, patcher and parent dir
- in most places the filesystem is assumed (asserted) to exist

This hopefully fixes #1267, though it also introduces potential crashes if a backlink is no longer available. While this _should_ not happen, it cannot be excluded, so this needs proper testing.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - n/a
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
