### PR TITLE
Make FakeFileWrapper.size a property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ The released versions correspond to PyPI releases.
 * use only `pyproject.toml` for dependencies, moved `tox` configuration into `pyproject.toml`
 
 ### Fixes
+* fixed a problem accessing `size` from a `FakeFileWrapper` object
+  (see [#1276](https://github.com/pytest-dev/pyfakefs/issues/1276))
 * fixed a problem with `readable` raising an error on a file object.
   (see [#1265](https://github.com/pytest-dev/pyfakefs/issues/1265))
 * avoid memory accumulation in consecutive tests by using weak references

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -1213,6 +1213,7 @@ class FakeFileWrapper:
 
         return truncate_wrapper
 
+    @property
     def size(self) -> int:
         """Return the content size in bytes of the wrapped file."""
         return self.file_object.st_size

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -5204,7 +5204,7 @@ class StatPropagationTest(TestCase):
         self.filesystem.create_file(file_path, st_size=size)
         fh = self.open(file_path, "r", encoding="utf8")
         fh.close()
-        self.assertEqual(size, self.open(file_path, "r", encoding="utf8").size())
+        self.assertEqual(size, self.open(file_path, "r", encoding="utf8").size)
 
     def test_file_size_after_write(self):
         file_path = "test_file"
@@ -5215,11 +5215,9 @@ class StatPropagationTest(TestCase):
         expected_size = original_size + len(added_content)
         fh = self.open(file_path, "a", encoding="utf8")
         fh.write(added_content)
-        self.assertEqual(original_size, fh.size())
+        self.assertEqual(original_size, fh.size)
         fh.close()
-        self.assertEqual(
-            expected_size, self.open(file_path, "r", encoding="utf8").size()
-        )
+        self.assertEqual(expected_size, self.open(file_path, "r", encoding="utf8").size)
 
     def test_large_file_size_after_write(self):
         file_path = "test_file"


### PR DESCRIPTION
- allows accessing the file property for fake files created with a fixed size
- also fixes django File size with a fake fs
- fixes #1276 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
