### PR TITLE
expanduser now correctly handles full paths and different separators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 The released versions correspond to PyPI releases.
 `pyfakefs` versions follow [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixes
+* expanduser now correctly handles paths besides home and different separators
+  (see [#1289](https://github.com/pytest-dev/pyfakefs/issues/1289))
+
 ## [Version 6.1.3](https://pypi.python.org/pypi/pyfakefs/6.1.3) (2026-03-01)
 Minor bugfix release.
 

--- a/pyfakefs/fake_path.py
+++ b/pyfakefs/fake_path.py
@@ -466,6 +466,7 @@ class FakePathModule:
         """Return the argument with an initial component of ~ or ~user
         replaced by that user's home directory.
         """
+        path = make_string_path(path)
         if (
             self.filesystem.is_windows_fs != (os.name == "nt")
             and matching_string(path, "~") == path[:1]
@@ -478,9 +479,14 @@ class FakePathModule:
                 sep = matching_string(path, self.sep)
                 home = sep + self._os_path.join("home", username)
             _, _, rest = path.partition(matching_string(path, self.sep))
-            path = self._os_path.join(home, *rest)
+            path = self._os_path.join(home, rest) if rest else home
         else:
-            path = self._os_path.expanduser(path)
+            path = self._os_path.expanduser(
+                path.replace(
+                    matching_string(path, self.sep),
+                    matching_string(path, self._os_path.sep),
+                )
+            )
         return path.replace(
             matching_string(path, self._os_path.sep),
             matching_string(path, self.sep),

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -786,8 +786,28 @@ class FakePath(pathlib.Path):
             other_st = self.filesystem.stat(other_path)
         return st.st_ino == other_st.st_ino and st.st_dev == other_st.st_dev
 
+    if sys.version_info < (3, 12):
+
+        @classmethod
+        def _normalize_path_sep(cls, path):
+            # In older Python, str() uses _flavour.sep, so we replace that
+            try:
+                return path.replace(
+                    cls._flavour.sep,  # pytype: disable=attribute-error
+                    cls.filesystem.path_separator,
+                )
+            except AttributeError:
+                return path
+    else:
+
+        @classmethod
+        def _normalize_path_sep(cls, path):
+            # In newer Python, we replace os.path.sep to normalize
+            return path.replace(os.path.sep, cls.filesystem.path_separator)
+
     @classmethod
     def _expand_user(cls, path):
+        path = cls._normalize_path_sep(path)
         if cls.filesystem.is_windows_fs != (os.name == "nt") and path[:1] == "~":
             home = os.path.expanduser("~")
             username = os.path.split(home)[1]
@@ -796,9 +816,11 @@ class FakePath(pathlib.Path):
             else:
                 home = cls.filesystem.path_separator + os.path.join("home", username)
             _, _, rest = path.partition(cls.filesystem.path_separator)
-            path = os.path.join(home, *rest)
+            path = os.path.join(home, rest) if rest else home
         else:
-            path = os.path.expanduser(path)
+            path = os.path.expanduser(
+                path.replace(cls.filesystem.path_separator, os.path.sep)
+            )
         return path
 
     def expanduser(self):

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -1121,9 +1121,24 @@ class FakePathModuleTest(TestCase):
 
     @unittest.skipIf(sys.platform != "win32", "Windows specific test")
     @patch.dict(os.environ, {"USERPROFILE": r"C:\Users\John"})
+    def test_expand_user_windows_path(self):
+        self.assertEqual(
+            self.path.expanduser("~!stuff!test.txt"), "C:!Users!John!stuff!test.txt"
+        )
+
+    @unittest.skipIf(sys.platform != "win32", "Windows specific test")
+    @patch.dict(os.environ, {"USERPROFILE": r"C:\Users\John"})
     def test_expand_user_windows_posixfs(self):
         self.filesystem.is_windows_fs = False
         self.assertEqual(self.path.expanduser("~"), "!home!John")
+
+    @unittest.skipIf(sys.platform != "win32", "Windows specific test")
+    @patch.dict(os.environ, {"USERPROFILE": r"C:\Users\John"})
+    def test_expand_user_windows_posixfs_path(self):
+        self.filesystem.is_windows_fs = False
+        self.assertEqual(
+            self.path.expanduser("~!stuff!test.txt"), "!home!John!stuff!test.txt"
+        )
 
     @unittest.skipIf(sys.platform == "win32", "Posix specific test")
     @patch.dict(os.environ, {"HOME": "/home/john"})
@@ -1132,9 +1147,24 @@ class FakePathModuleTest(TestCase):
 
     @unittest.skipIf(sys.platform == "win32", "Posix specific test")
     @patch.dict(os.environ, {"HOME": "/home/john"})
+    def test_expand_user_path(self):
+        self.assertEqual(
+            self.path.expanduser("~!stuff!test.txt"), "!home!john!stuff!test.txt"
+        )
+
+    @unittest.skipIf(sys.platform == "win32", "Posix specific test")
+    @patch.dict(os.environ, {"HOME": "/home/john"})
     def test_expand_user_posix_windowsfs(self):
         self.filesystem.is_windows_fs = True
         self.assertEqual(self.path.expanduser("~"), "C:!Users!john")
+
+    @unittest.skipIf(sys.platform == "win32", "Posix specific test")
+    @patch.dict(os.environ, {"HOME": "/home/john"})
+    def test_expand_user_posix_windowsfs_path(self):
+        self.filesystem.is_windows_fs = True
+        self.assertEqual(
+            self.path.expanduser("~!stuff!test.txt"), "C:!Users!john!stuff!test.txt"
+        )
 
     @patch.dict(os.environ, {}, clear=True)
     def test_expand_user_no_home_environment(self):

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -708,12 +708,30 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
 
     @unittest.skipIf(sys.platform != "win32", "Windows specific test")
     @patch.dict(os.environ, {"USERPROFILE": r"C:\Users\John"})
+    def test_expanduser_windows_path(self):
+        self.assertEqual(
+            self.path("~/stuff/test.txt").expanduser(),
+            self.path("C:/Users/John/stuff/test.txt"),
+        )
+
+    @unittest.skipIf(sys.platform != "win32", "Windows specific test")
+    @patch.dict(os.environ, {"USERPROFILE": r"C:\Users\John"})
     def test_expanduser_windows_posixfs(self):
         self.skip_real_fs()
         self.set_windows_fs(False)
         self.assertEqual(
             self.path("~").expanduser(),
             self.path("\\home\\John"),
+        )
+
+    @unittest.skipIf(sys.platform != "win32", "Windows specific test")
+    @patch.dict(os.environ, {"USERPROFILE": r"C:\Users\John"})
+    def test_expanduser_windows_posixfs_path(self):
+        self.skip_real_fs()
+        self.set_windows_fs(False)
+        self.assertEqual(
+            self.path("~/stuff/test.txt").expanduser(),
+            self.path("\\home\\John\\stuff\\test.txt"),
         )
 
     @unittest.skipIf(sys.platform == "win32", "Posix specific test")
@@ -723,10 +741,28 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
 
     @unittest.skipIf(sys.platform == "win32", "Posix specific test")
     @patch.dict(os.environ, {"HOME": "/home/john"})
+    def test_expanduser_posix_path(self):
+        self.assertEqual(
+            self.path("~/stuff/test.txt").expanduser(),
+            self.path("/home/john/stuff/test.txt"),
+        )
+
+    @unittest.skipIf(sys.platform == "win32", "Posix specific test")
+    @patch.dict(os.environ, {"HOME": "/home/john"})
     def test_expanduser_posix_windowsfs(self):
         self.skip_real_fs()
         self.set_windows_fs(True)
         self.assertEqual(self.path("~").expanduser(), self.path("C:/Users/john"))
+
+    @unittest.skipIf(sys.platform == "win32", "Posix specific test")
+    @patch.dict(os.environ, {"HOME": "/home/john"})
+    def test_expanduser_posix_windowsfs_path(self):
+        self.skip_real_fs()
+        self.set_windows_fs(True)
+        self.assertEqual(
+            self.path("~/stuff/test.txt").expanduser(),
+            self.path("C:/Users/john/stuff/test.txt"),
+        )
 
     @unittest.skipIf(sys.platform != "win32", "Windows specific test")
     @patch.dict(os.environ, {"USERPROFILE": r"C:\Users\John"})


### PR DESCRIPTION
#### Describe the changes
There was an issue with how the "rest" was injected into path.join. I originally had it as a list of the parts but then later changed it to just be a string of everything but the start and didnt change that part.

Also noticed that it was not behaving correctly with non-standard separators.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
