### PR TITLE
Fix os.path.realpath with absolute path (Windows)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,13 @@ The released versions correspond to PyPI releases.
 ## Unreleased
 
 ### Fixes
+* `os.path.realpath` did not correctly handle some absolute paths under Windows
+  (previous fix was incomplete, see [#1296](https://github.com/pytest-dev/pyfakefs/issues/1296))
+
+## [Version 6.1.5](https://pypi.python.org/pypi/pyfakefs/6.1.5) (2026-03-15)
+Minor bugfix release.
+
+### Fixes
 * `os.path.realpath` did not resolve symlinks under Windows
   (see [#1296](https://github.com/pytest-dev/pyfakefs/issues/1296))
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1158,7 +1158,7 @@ class FakeFilesystem:
             path = self.get_path_separator(path)
         if path == matching_string(path, "."):
             path = cwd
-        elif not self._starts_with_root_path(path):
+        elif not self.starts_with_root_path(path):
             # Prefix relative paths with cwd, if cwd is not root.
             root_name = matching_string(path, self.root.name)
             empty = matching_string(path, "")
@@ -1436,7 +1436,12 @@ class FakeFilesystem:
                     return False
         return False
 
-    def _starts_with_root_path(self, file_path: AnyStr) -> bool:
+    def starts_with_root_path(self, file_path: AnyStr) -> bool:
+        """Returns ``True`` if `file_path` starts with a root path.
+        Under Windows, this means it starts with a drive letter, an UNC path,
+        or a path separator (which would point to the current drive).
+        Under Posix it returns ``True`` if `file_path` starts with a path separator.
+        """
         root_name = matching_string(file_path, self.root.name)
         file_path = self._normalize_path_sep(file_path)
         return (
@@ -1637,7 +1642,7 @@ class FakeFilesystem:
             else self.path_separator
         )
         path = sep.join(component_folders)
-        if not self._starts_with_root_path(path):
+        if not self.starts_with_root_path(path):
             path = sep + path
         return path
 
@@ -1724,7 +1729,7 @@ class FakeFilesystem:
             # For links to absolute paths, we want to throw out everything
             # in the path built so far and replace with the link. For relative
             # links, we have to append the link to what we have so far,
-            if not self._starts_with_root_path(link_path):
+            if not self.starts_with_root_path(link_path):
                 # Relative path. Append remainder of path to what we have
                 # processed so far, excluding the name of the link itself.
                 # /a/b => ../c  should yield /a/../c

--- a/pyfakefs/fake_path.py
+++ b/pyfakefs/fake_path.py
@@ -411,10 +411,16 @@ class FakePathModule:
         pardir = matching_string(path, "..")
 
         sep = self.filesystem.get_path_separator(path)
-        if self.isabs(rest):
-            root = matching_string(path, self.filesystem.root_dir_name)
-            path = root
-            rest = rest[len(root) :]
+        if self.filesystem.starts_with_root_path(rest):
+            if self.filesystem.is_windows_fs:
+                drive, rest = self.filesystem.splitdrive(rest)
+                if not drive:
+                    cwd = matching_string(path, self.filesystem.cwd)
+                    drive, _ = self.filesystem.splitdrive(cwd)
+                path = drive + sep
+            else:
+                path = sep
+            rest = rest[1:]
 
         while rest:
             name, _, rest = rest.partition(sep)

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -1035,6 +1035,44 @@ class FakePathModuleTest(TestCase):
             f"{root_dir}foo!bar", self.os.path.realpath("bar", strict=True)
         )
 
+    def test_realpath_from_abs_path(self):
+        self.filesystem.create_file("!foo!bar")
+        root_dir = self.filesystem.root_dir_name
+        self.filesystem.cwd = f"{root_dir}foo"
+        self.assertEqual(f"{root_dir}baz", self.os.path.realpath("!baz", strict=False))
+        with self.raises_os_error(errno.ENOENT):
+            self.os.path.realpath("!baz", strict=True)
+        self.assertEqual(
+            f"{root_dir}foo!bar", self.os.path.realpath("!foo!bar", strict=True)
+        )
+
+    def test_realpath_from_path_starting_with_sep_in_windows(self):
+        self.filesystem.is_windows_fs = True
+        self.filesystem.cwd = "D:!foo"
+        self.filesystem.create_file("!foo!bar")
+        self.assertEqual("D:!baz", self.os.path.realpath("!baz", strict=False))
+        with self.raises_os_error(errno.ENOENT):
+            self.os.path.realpath("!baz", strict=True)
+        self.assertEqual("D:!foo!bar", self.os.path.realpath("!foo!bar", strict=True))
+
+    def test_realpath_from_bytes_path_starting_with_sep_in_windows(self):
+        self.filesystem.is_windows_fs = True
+        self.filesystem.cwd = "D:!foo"
+        self.filesystem.create_file("!foo!bar")
+        self.assertEqual(b"D:!baz", self.os.path.realpath(b"!baz", strict=False))
+        with self.raises_os_error(errno.ENOENT):
+            self.os.path.realpath(b"!baz", strict=True)
+        self.assertEqual(b"D:!foo!bar", self.os.path.realpath(b"!foo!bar", strict=True))
+
+    def test_realpath_from_path_with_drive(self):
+        self.filesystem.is_windows_fs = True
+        self.filesystem.cwd = "D:!foo"
+        self.filesystem.create_file("C:!foo!bar")
+        self.assertEqual("C:!baz", self.os.path.realpath("C:!baz", strict=False))
+        with self.raises_os_error(errno.ENOENT):
+            self.os.path.realpath("C:!baz", strict=True)
+        self.assertEqual("C:!foo!bar", self.os.path.realpath("C:!foo!bar", strict=True))
+
     @unittest.skipIf(
         not hasattr(os.path, "ALLOW_MISSING"),
         "ALLOW_MISSING has been added in different patch versions",


### PR DESCRIPTION
The fix from the previous patch release was incomplete - it didn't work correctly for absolute paths in some Python versions under Windows.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
