### PR TITLE
Route some pseudo-devices to the system

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 The released versions correspond to PyPI releases.
 `pyfakefs` versions follow [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixes
+* route some pseudo-devices to the system instead of patching them; this ensures
+  that `os.urandom` and related functions work correctly with PyPy
+  (see [#1300](https://github.com/pytest-dev/pyfakefs/issues/1300))
+
 ## [Version 6.1.6](https://pypi.python.org/pypi/pyfakefs/6.1.6) (2026-03-18)
 Follow-up bugfix release for 6.1.5.
 
@@ -20,7 +27,7 @@ Minor bugfix release.
 Fixes incompatibility with VCCode unittest runner.
 
 ### Fixes
-* expanduser now correctly handles paths besides home and different separators
+* `expanduser` now correctly handles paths besides home and different separators
   (see [#1289](https://github.com/pytest-dev/pyfakefs/issues/1289))
 * avoid faking filesystem in VSCode unittest runner
   (see [#1285](https://github.com/pytest-dev/pyfakefs/issues/1285))
@@ -29,7 +36,7 @@ Fixes incompatibility with VCCode unittest runner.
 Minor bugfix release.
 
 ### Fixes
-* handle expanduser() and home() correctly in cross OS usage
+* handle `expanduser()` and `home()` correctly in cross OS usage
   (see [#1289](https://github.com/pytest-dev/pyfakefs/issues/1289))
 
 ## [Version 6.1.2](https://pypi.python.org/pypi/pyfakefs/6.1.2) (2026-02-22)

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -525,6 +525,19 @@ If you encounter such a problem, there are several possibilities how to handle t
 * if you really need the large files, call `gc.collect`_ between tests to ensure that the
   garbage collector cleans up the memory
 
+Directly accessing device files in tests
+----------------------------------------
+Under Posix, (almost) everything is a file, and not all files are handled by pyfakefs.
+Specifically, files in the `/dev` directory represent devices. Accessing them directly
+using Python file system functions is not possible while patching with ``pyfakefs``, except
+for some pseudo-devices. The null device (`/dev/null`, or `NUL` under Windows) is patched
+to work as expected, and the pseudo-devices `/dev/random`, `/dev/urandom`, `/dev/zero` and
+`/dev/full` are just directly routed the system without patching them, as they have no
+side-effect on the real system.
+While this is rarely needed, some Python functions like `os.random` may rely on these,
+and in the case of the PyPy implementation, directly access them using Python functions.
+
+
 .. _`multiprocessing`: https://docs.python.org/3/library/multiprocessing.html
 .. _`subprocess`: https://docs.python.org/3/library/subprocess.html
 .. _`sqlite3`: https://docs.python.org/3/library/sqlite3.html

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -46,6 +46,7 @@ from pyfakefs.helpers import (
     PERM_READ,
     PERM_WRITE,
     _OpenModes,
+    is_unfaked_path,
 )
 
 if TYPE_CHECKING:
@@ -87,10 +88,14 @@ def fake_open(
     """
     # We don't need to check this if we are in an `open_code` call
     # from a faked file (and this might cause recursions in `linecache`)
-    if not is_fake_open_code and is_called_from_skipped_module(
-        skip_names=skip_names,
-        case_sensitive=filesystem.is_case_sensitive,
-        check_open_code=sys.version_info >= (3, 12),
+    if (
+        not is_fake_open_code
+        and is_called_from_skipped_module(
+            skip_names=skip_names,
+            case_sensitive=filesystem.is_case_sensitive,
+            check_open_code=sys.version_info >= (3, 12),
+        )
+        or is_unfaked_path(file)
     ):
         return io_open(  # pytype: disable=wrong-arg-count
             file,

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -207,6 +207,24 @@ def matching_string(  # type: ignore[misc]
     return string  # pytype: disable=bad-return-type
 
 
+def is_unfaked_path(val: Any) -> bool:
+    """Return ``True`` if `val` is a path that should not be faked.
+    Currently only ``True`` for some pseudo-devices under Posix,
+    which will have no side effect if reading/writing them.
+    """
+    if IS_WIN:
+        return False
+    try:
+        return matching_string("", val) in (
+            "/dev/random",
+            "/dev/urandom",
+            "/dev/zero",
+            "/dev/full",
+        )
+    except AttributeError:
+        return False
+
+
 @dataclass
 class FSProperties:
     sep: str

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -995,6 +995,18 @@ class FakeFileOpenTest(FakeFileOpenTestBase):
             with self.open(self.os.devnull, encoding="utf8") as f:
                 self.assertEqual("", f.read())
 
+    @unittest.skipIf(os.name == "nt", "only exist on posix")
+    def test_pseudo_devices(self):
+        self.check_posix_only()
+        with self.open("/dev/random", "rb") as f:
+            self.assertEqual(1, len(f.read(1)))
+        with self.open("/dev/zero", "rb") as f:
+            self.assertEqual(b"\0\0\0\0", f.read(4))
+        if sys.platform == "linux":
+            with self.raises_os_error(errno.ENOSPC):
+                with self.open("/dev/full", "wb") as f:
+                    f.write(b"\0")
+
     def test_utf16_text(self):
         # regression test for #574
         file_path = self.make_path("foo")


### PR DESCRIPTION
- fixes os.urandom() and related under PyPy
- fixes #1300

This came up in a test that generated a random number, which internally used `os.urandom` and failed under PyPy.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
