### PR TITLE
fix(FakeFileWrapper): correctly return the location in the file from seek

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ The released versions correspond to PyPI releases.
 * route some pseudo-devices to the system instead of patching them; this ensures
   that `os.urandom` and related functions work correctly with PyPy
   (see [#1300](https://github.com/pytest-dev/pyfakefs/issues/1300))
+* fake file `seek` method did not return the location in the file
+  (see [#1304](https://github.com/pytest-dev/pyfakefs/issues/1304))
 
 ## [Version 6.1.6](https://pypi.python.org/pypi/pyfakefs/6.1.6) (2026-03-18)
 Follow-up bugfix release for 6.1.5.

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -995,7 +995,7 @@ class FakeFileWrapper:
                     ):
                         open_file._sync_io()
 
-    def seek(self, offset: int, whence: int = 0) -> None:
+    def seek(self, offset: int, whence: int = 0) -> int:
         """Move read/write pointer in 'file'."""
         self._check_open_file()
         if not self.open_modes.append:
@@ -1005,6 +1005,7 @@ class FakeFileWrapper:
             self._read_whence = whence
         if not self.is_stream:
             self.flush()
+        return self.tell()
 
     def tell(self) -> int:
         """Return the file's current position.

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -903,6 +903,14 @@ class FakeFileOpenTest(FakeFileOpenTestBase):
             f0.seek(3)
             self.assertEqual(4, self.os.path.getsize(file_path))
 
+    def test_seek_returns_location(self):
+        # Regression test for #1304
+        file_path = self.make_path("foo")
+        with self.open(file_path, "w", encoding="utf8") as f0:
+            f0.write("test")
+            result = f0.seek(3)
+            self.assertEqual(3, result)
+
     def test_truncate_flushes(self):
         # Regression test for #291
         file_path = self.make_path("foo")


### PR DESCRIPTION
#### Describe the changes
Fixes #1304


#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
