### PR TITLE
Fix handling of case-sensitivity for fake posixpath

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ The released versions correspond to PyPI releases.
   (see [#1300](https://github.com/pytest-dev/pyfakefs/issues/1300))
 * fake file `seek` method did not return the location in the file
   (see [#1304](https://github.com/pytest-dev/pyfakefs/issues/1304))
+* make sure case sensitivity is correctly set for fake posix paths
+  in `hash()`, `Path.match` and `Path.full_match`
+  (see [#1308](https://github.com/pytest-dev/pyfakefs/issues/1308))
 
 ## [Version 6.1.6](https://pypi.python.org/pypi/pyfakefs/6.1.6) (2026-03-18)
 Follow-up bugfix release for 6.1.5.

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -798,6 +798,7 @@ class FakePath(pathlib.Path):
                 )
             except AttributeError:
                 return path
+
     else:
 
         @classmethod
@@ -1037,10 +1038,18 @@ class FakePathlibModule:
 
             return grp.getgrgid(self.stat().st_gid).gr_name
 
+        if sys.version_info >= (3, 13):
+
+            def __init__(self, *args):
+                super().__init__(*args)
+                # case-sensitivity for filling the _str_normcase_cached variable
+                # is filled depending on a class check (self.parser is posixpath),
+                # which we cannot fake, thus we set it at initialization time
+                self._str_normcase_cached = str(self)
+
         if sys.version_info >= (3, 14):
-            # in Python 3.14, case-sensitivity is checked using an is-check
-            # (self.parser is posixpath) if not given, which we cannot fake
-            # therefore we already provide the case sensitivity under Posix
+            # a similar check is used in the implementations of glob, match and full_match, to check for
+            # case sensitivity if not given, so we provide it under Posix as True
             def glob(self, pattern, *, case_sensitive=None, recurse_symlinks=False):
                 if case_sensitive is None:
                     case_sensitive = True
@@ -1049,6 +1058,20 @@ class FakePathlibModule:
                     case_sensitive=case_sensitive,
                     recurse_symlinks=recurse_symlinks,
                 )
+
+            def match(self, path_pattern, *, case_sensitive=None):
+                if case_sensitive is None:
+                    case_sensitive = True
+                return super().match(
+                    path_pattern, case_sensitive=case_sensitive
+                )  # pytype: disable=wrong-keyword-args
+
+            def full_match(self, pattern, *, case_sensitive=None):
+                if case_sensitive is None:
+                    case_sensitive = True
+                return super().full_match(  # pytype: disable=attribute-error
+                    pattern, case_sensitive=case_sensitive
+                )  # pytype: disable=wrong-keyword-args
 
     Path = FakePath
 

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -265,6 +265,36 @@ class FakePathlibPurePathTest(RealPathlibTestCase):
         self.assertTrue(self.path("/a.py").match("/*.py"))
         self.assertFalse(self.path("a/b.py").match("/*.py"))
 
+    @unittest.skipIf(sys.version_info < (3, 13), "full_match new in Python 3.13")
+    def test_full_match(self):
+        self.assertFalse(self.path("a/b.py").full_match("*.py"))
+        self.assertTrue(self.path("/a/b.py").full_match("/a/*.py"))
+        self.assertTrue(self.path("/a/b/c.py").full_match("/a/**"))
+
+    def test_match_with_differing_case_posix(self):
+        self.check_posix_only()
+        self.assertFalse(self.path("a/b.py").match("*.Py"))
+        self.assertFalse(self.path("/a/b/c.py").match("B/*.py"))
+        self.assertFalse(self.path("/a.py").match("/*.PY"))
+
+    def test_match_with_differing_case_windows(self):
+        self.check_windows_only()
+        self.assertTrue(self.path("a/b.py").match("*.Py"))
+        self.assertTrue(self.path("/a/b/c.py").match("B/*.py"))
+        self.assertTrue(self.path("/a.py").match("/*.PY"))
+
+    @unittest.skipIf(sys.version_info < (3, 13), "full_match new in Python 3.13")
+    def test_full_match_with_differing_case_posix(self):
+        self.check_posix_only()
+        self.assertFalse(self.path("/a/b.py").full_match("/a/*.PY"))
+        self.assertFalse(self.path("/a/b/c.py").full_match("/A/**"))
+
+    @unittest.skipIf(sys.version_info < (3, 13), "full_match new in Python 3.13")
+    def test_full_match_with_differing_case_windows(self):
+        self.check_windows_only()
+        self.assertTrue(self.path("/a/b.py").full_match("/a/*.PY"))
+        self.assertTrue(self.path("/a/b/c.py").full_match("/A/**"))
+
     def test_relative_to(self):
         self.assertEqual(
             self.path("/etc/passwd").relative_to("/"), self.path("etc/passwd")
@@ -297,6 +327,20 @@ class FakePathlibPurePathTest(RealPathlibTestCase):
         self.assertEqual(
             self.path("README").with_suffix(".txt"), self.path("README.txt")
         )
+
+    def test_path_comparison_posix(self):
+        self.check_posix_only()
+        path1 = self.path("Test")
+        path2 = self.path("test")
+        assert path1 != path2
+        assert hash(path1) != hash(path2)
+
+    def test_path_comparison_windows(self):
+        self.check_windows_only()
+        path1 = self.path("Test")
+        path2 = self.path("test")
+        assert path1 == path2
+        assert hash(path1) == hash(path2)
 
 
 class RealPathlibPurePathTest(FakePathlibPurePathTest):


### PR DESCRIPTION
- relates to hash() (since Python 3.13), match() and full_match() (since Python 3.14)
- fixes #1308 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
