### PR TITLE
Fake file wrappers now derive from io.Base classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Changes
+* fake file wrappers now derive from `io.TextIOBase` or `io.BufferedIOBase`,
+  so that `isinstance`-checks for these classes succeed
+  (see [#1307](https://github.com/pytest-dev/pyfakefs/issues/1307)
+  and [#484](https://github.com/pytest-dev/pyfakefs/issues/484))
+
 ### Fixes
 * route some pseudo-devices to the system instead of patching them; this ensures
   that `os.urandom` and related functions work correctly with PyPy

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -72,9 +72,10 @@ Limitations
   See :ref:`customizing_patcher` for more information and ways to work around
   this.
 
-- ``pyfakefs`` does not retain the MRO for file objects, so you cannot rely on
-  checks using `isinstance` for these objects (for example, to differentiate
-  between binary and textual file objects).
+- ``pyfakefs`` does not retain the MRO for file objects, so you can mostly not rely on
+  checks using `isinstance` for these objects (note though that binary and textual file
+  objects are derived from `io.BufferedIOBase` and `io.TextIOBase`, respectively,
+  and can thus be differentiated via `isinstance` checks).
 
 - ``pyfakefs`` is only tested with CPython and the newest PyPy versions, other
   Python implementations will probably not work

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -1286,12 +1286,38 @@ class FakeFileWrapper:
     def __iter__(self) -> Iterator[str] | Iterator[bytes]:
         if not self.readable():
             self._raise("File is not open for reading")
-        return self._io.__iter__()
+        return self._io.__iter__()  # type: ignore[return-value]
 
     def __next__(self):
         if not self.readable():
             self._raise("File is not open for reading")
         return next(self._io)
+
+
+class FakeTextFileWrapper(FakeFileWrapper, io.TextIOBase):  # type: ignore[misc]
+    """Represents a text file wrapper.
+    Derives from io.TextIOBase so it can be used as a file object
+    if the type is checked by a library user, while it delegates all calls
+    to `FakeFileWrapper`.
+    """
+
+    def __getattribute__(self, name):  # type: ignore[override]
+        if hasattr(FakeFileWrapper, name) or name in self.__dict__:
+            return FakeFileWrapper.__getattribute__(self, name)
+        return self.__getattr__(name)
+
+
+class FakeBinaryFileWrapper(FakeFileWrapper, io.BufferedIOBase):  # type: ignore[misc]
+    """Represents a buffered binary file wrapper.
+    Derives from io.BufferedIOBase so it can be used as a file object
+    if the type is checked by a library user, while it delegates all calls
+    to `FakeFileWrapper`.
+    """
+
+    def __getattribute__(self, name):  # type: ignore[override]
+        if hasattr(FakeFileWrapper, name) or name in self.__dict__:
+            return FakeFileWrapper.__getattribute__(self, name)
+        return self.__getattr__(name)
 
 
 class StandardStreamWrapper:

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -32,13 +32,15 @@ from typing import (
     IO,
 )
 
-from pyfakefs import helpers
 from pyfakefs.fake_file import (
+    FakeBinaryFileWrapper,
+    FakeTextFileWrapper,
     FakePipeWrapper,
     FakeFileWrapper,
     FakeFile,
     AnyFileWrapper,
 )
+from pyfakefs import helpers
 from pyfakefs.helpers import (
     AnyString,
     is_called_from_skipped_module,
@@ -270,7 +272,8 @@ class FakeFileOpen:
             if not self.filesystem.is_windows_fs:
                 file_object.st_ctime = current_time
 
-        fakefile = FakeFileWrapper(
+        wrapper_class = FakeBinaryFileWrapper if binary else FakeTextFileWrapper
+        fakefile = wrapper_class(
             file_object,
             file_path,
             open_modes=open_modes,

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -1051,6 +1051,18 @@ class FakeFileOpenTest(FakeFileOpenTestBase):
             self.assertTrue(f.readable())
             self.assertTrue(f.writable())
 
+    def test_file_class(self):
+        file_path = self.make_path("foo")
+        with self.open(file_path, "w") as f:
+            assert isinstance(f, io.TextIOBase)
+            f.write("test")
+        with self.open(file_path) as f:
+            assert isinstance(f, io.TextIOBase)
+            assert f.read() == "test"
+        with self.open(file_path, "rb") as f:
+            assert isinstance(f, io.BufferedIOBase)
+            assert f.read() == b"test"
+
 
 class RealFileOpenTest(FakeFileOpenTest):
     def use_real_fs(self):


### PR DESCRIPTION
- text file wrappers derive from `io.TextIOBase`
- binary file wrappers derive from `io.BufferedIOBase`
- fixes checks for base classes, see #1307 and #484

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
